### PR TITLE
docs: added src/ to modules.lst

### DIFF
--- a/kamailio-install-guide-git/docs/index.md
+++ b/kamailio-install-guide-git/docs/index.md
@@ -80,9 +80,9 @@ The first step is to generate build config files.
 Next step is to enable the MySQL module. Edit **modules.lst** file:
 
 ```Shell
-  nano -w modules.lst
+  nano -w src/modules.lst
   # or
-  vim modules.lst
+  vim src/modules.lst
 ```
 
 Add **db_mysql** to the variable **include_modules**.


### PR DESCRIPTION
In index.md, src/ was prefixed to vim src/modules.lst as this is
the new location of modules.lst