### PR TITLE
kamailio-kemi-framework: Added documentation for modules

### DIFF
--- a/kamailio-kemi-framework/docs/core.md
+++ b/kamailio-kemi-framework/docs/core.md
@@ -33,7 +33,7 @@ Write a log message to ERROR level.
 
 Write a log message to INFO level.
 
-### oid KSR.log(...) ###
+### void KSR.log(...) ###
 
 `void KSR.log("level", "msg")`
 

--- a/kamailio-kemi-framework/docs/extra.css
+++ b/kamailio-kemi-framework/docs/extra.css
@@ -14,6 +14,15 @@
 .wy-side-nav-search {
 	background: #222c32;
 }
+
 .rst-versions {
 	border-top:solid 10px #222c32;
+}
+
+.wy-menu-vertical a {
+    color: #f1f1f1
+}
+
+li.current a {
+    color: #212121
 }

--- a/kamailio-kemi-framework/docs/index.md
+++ b/kamailio-kemi-framework/docs/index.md
@@ -3,6 +3,8 @@
 ```
 Author: Daniel-Constantin Mierla (miconda@gmail.com)
 
+Contributors: Samuel Förnes
+
 Support: <sr-users@lists.kamailio.org>
 ```
 
@@ -63,7 +65,7 @@ With KEMI routing script, the `kamailio.cfg` keeps only the parts with:
 All of these parts are evaluated only once at startup. Many of the global and module parameters can be changed at
 runtime via `RPC` commands.
 
-The KEMI comes in the picture by allowing that the equivalend of routing blocks to be written in a different scripting
+The KEMI comes in the picture by allowing the equivalent of routing blocks to be written in a different scripting
 language. In other words, the routing blocks are now functions written in a KEMI supported scripting language.
 
 For each new KEMI supported scripting language a module has to be developed for Kamailio, this module linking

--- a/kamailio-kemi-framework/docs/modules.md
+++ b/kamailio-kemi-framework/docs/modules.md
@@ -1,0 +1,436 @@
+<!-- This file is auto-generated. Any manual modifications will be deleted -->
+# KEMI Module Functions #
+The following sections lists all exported KEMI functions. More information regarding the function can be found by clicking the KEMI declaration which will take you the original modules documentation. 
+## app_python ##
+#### KSR.app_python.exec() ####
+KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/app_python.html#app_python.f.exec'> `int exec(str)` </a> 
+
+Docs declaration: `int exec(method [, args])`
+#### KSR.app_python.exec_p1() ####
+KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/app_python.html#app_python.f.exec_p1'> `int exec_p1(str, str)` </a> 
+
+## corex ##
+#### KSR.corex.append_branch() ####
+KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/corex.html#corex.f.append_branch'> `int append_branch()` </a> 
+
+#### KSR.corex.append_branch_uri() ####
+KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/corex.html#corex.f.append_branch_uri'> `int append_branch_uri(str)` </a> 
+
+#### KSR.corex.append_branch_uri_q() ####
+KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/corex.html#corex.f.append_branch_uri_q'> `int append_branch_uri_q(str, str)` </a> 
+
+## jsonrpcs ##
+#### KSR.jsonrpcs.exec() ####
+KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/jsonrpcs.html#jsonrpcs.f.exec'> `int exec(str)` </a> 
+
+Docs declaration: `int exec(cmd)`
+## kex ##
+#### KSR.kex.resetdebug() ####
+KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/kex.html#kex.f.resetdebug'> `int resetdebug(str, str)` </a> 
+
+#### KSR.kex.setdebug() ####
+KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/kex.html#kex.f.setdebug'> `int setdebug(int)` </a> 
+
+Docs declaration: `int setdebug(level)`
+## maxfwd ##
+#### KSR.maxfwd.process_maxfwd() ####
+KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/maxfwd.html#maxfwd.f.process_maxfwd'> `int process_maxfwd(int)` </a> 
+
+Docs declaration: `int process_maxfwd(max_value)`
+## pvx ##
+#### KSR.pvx.evalx() ####
+KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/pvx.html#pvx.f.evalx'> `int evalx(str, str)` </a> 
+
+#### KSR.pvx.pv_var_to_xavp() ####
+KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/pvx.html#pvx.f.pv_var_to_xavp'> `int pv_var_to_xavp(str, str)` </a> 
+
+#### KSR.pvx.pv_xavp_print() ####
+KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/pvx.html#pvx.f.pv_xavp_print'> `int pv_xavp_print()` </a> 
+
+#### KSR.pvx.pv_xavp_to_var() ####
+KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/pvx.html#pvx.f.pv_xavp_to_var'> `int pv_xavp_to_var(str)` </a> 
+
+#### KSR.pvx.sbranch_append() ####
+KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/pvx.html#pvx.f.sbranch_append'> `int sbranch_append()` </a> 
+
+#### KSR.pvx.sbranch_reset() ####
+KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/pvx.html#pvx.f.sbranch_reset'> `int sbranch_reset()` </a> 
+
+#### KSR.pvx.sbranch_set_ruri() ####
+KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/pvx.html#pvx.f.sbranch_set_ruri'> `int sbranch_set_ruri()` </a> 
+
+#### KSR.pvx.xavp_params_explode() ####
+KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/pvx.html#pvx.f.xavp_params_explode'> `int xavp_params_explode(str, str)` </a> 
+
+## rr ##
+#### KSR.rr.add_rr_param() ####
+KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/rr.html#rr.f.add_rr_param'> `int add_rr_param(str)` </a> 
+
+Docs declaration: `int add_rr_param()`
+#### KSR.rr.check_route_param() ####
+KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/rr.html#rr.f.check_route_param'> `int check_route_param(str)` </a> 
+
+Docs declaration: `int check_route_param(re)`
+#### KSR.rr.loose_route() ####
+KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/rr.html#rr.f.loose_route'> `int loose_route()` </a> 
+
+#### KSR.rr.record_route() ####
+KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/rr.html#rr.f.record_route'> `int record_route()` </a> 
+
+#### KSR.rr.record_route_params() ####
+KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/rr.html#rr.f.record_route_params'> `int record_route_params(str)` </a> 
+
+#### KSR.rr.remove_record_route() ####
+KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/rr.html#rr.f.remove_record_route'> `int remove_record_route()` </a> 
+
+## sanity ##
+#### KSR.sanity.sanity_check() ####
+KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/sanity.html#sanity.f.sanity_check'> `int sanity_check(int, int)` </a> 
+
+Docs declaration: `int sanity_check([msg_checks [, uri_checks]])`
+#### KSR.sanity.sanity_check_defaults() ####
+KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/sanity.html#sanity.f.sanity_check_defaults'> `int sanity_check_defaults()` </a> 
+
+## siputils ##
+#### KSR.siputils.has_totag() ####
+KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/siputils.html#siputils.f.has_totag'> `int has_totag()` </a> 
+
+#### KSR.siputils.is_first_hop() ####
+KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/siputils.html#siputils.f.is_first_hop'> `int is_first_hop()` </a> 
+
+#### KSR.siputils.is_reply() ####
+KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/siputils.html#siputils.f.is_reply'> `int is_reply()` </a> 
+
+#### KSR.siputils.is_request() ####
+KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/siputils.html#siputils.f.is_request'> `int is_request()` </a> 
+
+## sl ##
+#### KSR.sl.send_reply() ####
+KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/sl.html#sl.f.send_reply'> `int send_reply(int, str)` </a> 
+
+Docs declaration: `int send_reply(code, reason)`
+#### KSR.sl.sl_forward_reply() ####
+KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/sl.html#sl.f.sl_forward_reply'> `int sl_forward_reply(str, str)` </a> 
+
+Docs declaration: `int sl_forward_reply("404", "Not found")`
+#### KSR.sl.sl_reply_error() ####
+KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/sl.html#sl.f.sl_reply_error'> `int sl_reply_error()` </a> 
+
+#### KSR.sl.sl_send_reply() ####
+KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/sl.html#sl.f.sl_send_reply'> `int sl_send_reply(int, str)` </a> 
+
+Docs declaration: `int sl_send_reply(code, reason)`
+## textops ##
+#### KSR.textops.cmp_istr() ####
+KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/textops.html#textops.f.cmp_istr'> `int cmp_istr(str, str)` </a> 
+
+Docs declaration: `int cmp_istr(str1, str2)`
+#### KSR.textops.cmp_str() ####
+KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/textops.html#textops.f.cmp_str'> `int cmp_str(str, str)` </a> 
+
+Docs declaration: `int cmp_str(str1, str2)`
+#### KSR.textops.filter_body() ####
+KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/textops.html#textops.f.filter_body'> `int filter_body(str)` </a> 
+
+Docs declaration: `int filter_body(content_type)`
+#### KSR.textops.has_body() ####
+KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/textops.html#textops.f.has_body'> `int has_body()` </a> 
+
+#### KSR.textops.has_body_type() ####
+KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/textops.html#textops.f.has_body_type'> `int has_body_type(str)` </a> 
+
+#### KSR.textops.is_audio_on_hold() ####
+KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/textops.html#textops.f.is_audio_on_hold'> `int is_audio_on_hold()` </a> 
+
+#### KSR.textops.is_list() ####
+KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/textops.html#textops.f.is_list'> `int is_list(str, str, str)` </a> 
+
+#### KSR.textops.is_present_hf() ####
+KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/textops.html#textops.f.is_present_hf'> `int is_present_hf(str)` </a> 
+
+Docs declaration: `int is_present_hf(hf_name)`
+#### KSR.textops.is_present_hf_re() ####
+KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/textops.html#textops.f.is_present_hf_re'> `int is_present_hf_re(str)` </a> 
+
+Docs declaration: `int is_present_hf_re(hf_name_re)`
+#### KSR.textops.is_privacy() ####
+KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/textops.html#textops.f.is_privacy'> `int is_privacy(str)` </a> 
+
+Docs declaration: `int is_privacy(privacy_type)`
+#### KSR.textops.remove_hf_exp() ####
+KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/textops.html#textops.f.remove_hf_exp'> `int remove_hf_exp(str, str)` </a> 
+
+Docs declaration: `int remove_hf_exp(expmatch, expskip)`
+#### KSR.textops.remove_hf_re() ####
+KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/textops.html#textops.f.remove_hf_re'> `int remove_hf_re(str)` </a> 
+
+Docs declaration: `int remove_hf_re(re)`
+#### KSR.textops.replace() ####
+KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/textops.html#textops.f.replace'> `int replace(str, str)` </a> 
+
+Docs declaration: `int replace(re, txt)`
+#### KSR.textops.replace_all() ####
+KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/textops.html#textops.f.replace_all'> `int replace_all(str, str)` </a> 
+
+Docs declaration: `int replace_all(re, txt)`
+#### KSR.textops.replace_body() ####
+KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/textops.html#textops.f.replace_body'> `int replace_body(str, str)` </a> 
+
+Docs declaration: `int replace_body(re, txt)`
+#### KSR.textops.replace_body_all() ####
+KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/textops.html#textops.f.replace_body_all'> `int replace_body_all(str, str)` </a> 
+
+Docs declaration: `int replace_body_all(re, txt)`
+#### KSR.textops.replace_body_atonce() ####
+KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/textops.html#textops.f.replace_body_atonce'> `int replace_body_atonce(str, str)` </a> 
+
+Docs declaration: `int replace_body_atonce(re, txt)`
+#### KSR.textops.search() ####
+KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/textops.html#textops.f.search'> `int search(str)` </a> 
+
+Docs declaration: `int search(re)`
+#### KSR.textops.search_append() ####
+KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/textops.html#textops.f.search_append'> `int search_append(str)` </a> 
+
+Docs declaration: `int search_append(re, txt)`
+#### KSR.textops.search_append_body() ####
+KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/textops.html#textops.f.search_append_body'> `int search_append_body(str)` </a> 
+
+Docs declaration: `int search_append_body(re, txt)`
+#### KSR.textops.search_body() ####
+KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/textops.html#textops.f.search_body'> `int search_body(str)` </a> 
+
+Docs declaration: `int search_body(re)`
+#### KSR.textops.search_hf() ####
+KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/textops.html#textops.f.search_hf'> `int search_hf(str, str, str)` </a> 
+
+Docs declaration: `int search_hf(hf, re, flags)`
+#### KSR.textops.set_body() ####
+KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/textops.html#textops.f.set_body'> `int set_body(str, str)` </a> 
+
+Docs declaration: `int set_body(txt,content_type)`
+#### KSR.textops.set_reply_body() ####
+KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/textops.html#textops.f.set_reply_body'> `int set_reply_body(str, str)` </a> 
+
+Docs declaration: `int set_reply_body(txt,content_type)`
+#### KSR.textops.starts_with() ####
+KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/textops.html#textops.f.starts_with'> `int starts_with(str, str)` </a> 
+
+Docs declaration: `int starts_with(str1, str2)`
+#### KSR.textops.subst() ####
+KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/textops.html#textops.f.subst'> `int subst(str)` </a> 
+
+Docs declaration: `int subst('/re/repl/flags')`
+#### KSR.textops.subst_body() ####
+KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/textops.html#textops.f.subst_body'> `int subst_body(str)` </a> 
+
+Docs declaration: `int subst_body('/re/repl/flags')`
+#### KSR.textops.subst_hf() ####
+KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/textops.html#textops.f.subst_hf'> `int subst_hf(str, str, str)` </a> 
+
+Docs declaration: `int subst_hf(hf, subexp, flags)`
+#### KSR.textops.subst_uri() ####
+KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/textops.html#textops.f.subst_uri'> `int subst_uri(str)` </a> 
+
+Docs declaration: `int subst_uri('/re/repl/flags')`
+#### KSR.textops.subst_user() ####
+KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/textops.html#textops.f.subst_user'> `int subst_user(str)` </a> 
+
+Docs declaration: `int subst_user('/re/repl/flags')`
+## tm ##
+#### KSR.tm.t_any_replied() ####
+KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/tm.html#tm.f.t_any_replied'> `int t_any_replied()` </a> 
+
+#### KSR.tm.t_any_timeout() ####
+KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/tm.html#tm.f.t_any_timeout'> `int t_any_timeout()` </a> 
+
+#### KSR.tm.t_branch_replied() ####
+KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/tm.html#tm.f.t_branch_replied'> `int t_branch_replied()` </a> 
+
+#### KSR.tm.t_branch_timeout() ####
+KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/tm.html#tm.f.t_branch_timeout'> `int t_branch_timeout()` </a> 
+
+#### KSR.tm.t_check_trans() ####
+KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/tm.html#tm.f.t_check_trans'> `int t_check_trans()` </a> 
+
+#### KSR.tm.t_drop_replies() ####
+KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/tm.html#tm.f.t_drop_replies'> `int t_drop_replies(str)` </a> 
+
+Docs declaration: `int t_drop_replies([mode])`
+#### KSR.tm.t_drop_replies_all() ####
+KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/tm.html#tm.f.t_drop_replies_all'> `int t_drop_replies_all()` </a> 
+
+#### KSR.tm.t_grep_status() ####
+KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/tm.html#tm.f.t_grep_status'> `int t_grep_status(int)` </a> 
+
+Docs declaration: `int t_grep_status("code")`
+#### KSR.tm.t_is_canceled() ####
+KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/tm.html#tm.f.t_is_canceled'> `int t_is_canceled()` </a> 
+
+#### KSR.tm.t_is_expired() ####
+KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/tm.html#tm.f.t_is_expired'> `int t_is_expired()` </a> 
+
+#### KSR.tm.t_is_retr_async_reply() ####
+KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/tm.html#tm.f.t_is_retr_async_reply'> `int t_is_retr_async_reply()` </a> 
+
+#### KSR.tm.t_is_set() ####
+KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/tm.html#tm.f.t_is_set'> `int t_is_set(str)` </a> 
+
+Docs declaration: `int t_is_set(target)`
+#### KSR.tm.t_load_contacts() ####
+KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/tm.html#tm.f.t_load_contacts'> `int t_load_contacts()` </a> 
+
+#### KSR.tm.t_lookup_cancel() ####
+KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/tm.html#tm.f.t_lookup_cancel'> `int t_lookup_cancel()` </a> 
+
+#### KSR.tm.t_lookup_cancel_flags() ####
+KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/tm.html#tm.f.t_lookup_cancel_flags'> `int t_lookup_cancel_flags(int)` </a> 
+
+#### KSR.tm.t_lookup_request() ####
+KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/tm.html#tm.f.t_lookup_request'> `int t_lookup_request()` </a> 
+
+#### KSR.tm.t_newtran() ####
+KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/tm.html#tm.f.t_newtran'> `int t_newtran()` </a> 
+
+#### KSR.tm.t_next_contact_flow() ####
+KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/tm.html#tm.f.t_next_contact_flow'> `int t_next_contact_flow()` </a> 
+
+#### KSR.tm.t_next_contacts() ####
+KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/tm.html#tm.f.t_next_contacts'> `int t_next_contacts()` </a> 
+
+#### KSR.tm.t_on_branch() ####
+KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/tm.html#tm.f.t_on_branch'> `int t_on_branch(str)` </a> 
+
+Docs declaration: `int t_on_branch(branch_route)`
+#### KSR.tm.t_on_branch_failure() ####
+KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/tm.html#tm.f.t_on_branch_failure'> `int t_on_branch_failure(str)` </a> 
+
+Docs declaration: `int t_on_branch_failure(branch_failure_route)`
+#### KSR.tm.t_on_failure() ####
+KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/tm.html#tm.f.t_on_failure'> `int t_on_failure(str)` </a> 
+
+Docs declaration: `int t_on_failure(failure_route)`
+#### KSR.tm.t_on_reply() ####
+KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/tm.html#tm.f.t_on_reply'> `int t_on_reply(str)` </a> 
+
+Docs declaration: `int t_on_reply(onreply_route)`
+#### KSR.tm.t_relay() ####
+KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/tm.html#tm.f.t_relay'> `int t_relay()` </a> 
+
+#### KSR.tm.t_release() ####
+KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/tm.html#tm.f.t_release'> `int t_release()` </a> 
+
+#### KSR.tm.t_replicate() ####
+KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/tm.html#tm.f.t_replicate'> `int t_replicate(str)` </a> 
+
+Docs declaration: `int t_replicate([params])`
+#### KSR.tm.t_reply() ####
+KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/tm.html#tm.f.t_reply'> `int t_reply(int, str)` </a> 
+
+Docs declaration: `int t_reply(code, reason_phrase)`
+#### KSR.tm.t_reset_fr() ####
+KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/tm.html#tm.f.t_reset_fr'> `int t_reset_fr()` </a> 
+
+#### KSR.tm.t_reset_max_lifetime() ####
+KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/tm.html#tm.f.t_reset_max_lifetime'> `int t_reset_max_lifetime()` </a> 
+
+#### KSR.tm.t_reset_retr() ####
+KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/tm.html#tm.f.t_reset_retr'> `int t_reset_retr()` </a> 
+
+#### KSR.tm.t_retransmit_reply() ####
+KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/tm.html#tm.f.t_retransmit_reply'> `int t_retransmit_reply()` </a> 
+
+#### KSR.tm.t_save_lumps() ####
+KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/tm.html#tm.f.t_save_lumps'> `int t_save_lumps()` </a> 
+
+#### KSR.tm.t_set_auto_inv_100() ####
+KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/tm.html#tm.f.t_set_auto_inv_100'> `int t_set_auto_inv_100(int)` </a> 
+
+Docs declaration: `int t_set_auto_inv_100(0|1)`
+#### KSR.tm.t_set_disable_6xx() ####
+KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/tm.html#tm.f.t_set_disable_6xx'> `int t_set_disable_6xx(int)` </a> 
+
+Docs declaration: `int t_set_disable_6xx(0|1)`
+#### KSR.tm.t_set_disable_failover() ####
+KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/tm.html#tm.f.t_set_disable_failover'> `int t_set_disable_failover(int)` </a> 
+
+Docs declaration: `int t_set_disable_failover(0|1)`
+#### KSR.tm.t_set_disable_internal_reply() ####
+KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/tm.html#tm.f.t_set_disable_internal_reply'> `int t_set_disable_internal_reply(int)` </a> 
+
+Docs declaration: `int t_set_disable_internal_reply(0|1)`
+#### KSR.tm.t_set_fr() ####
+KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/tm.html#tm.f.t_set_fr'> `int t_set_fr(int, int)` </a> 
+
+Docs declaration: `int t_set_fr(fr_inv_timeout [, fr_timeout])`
+#### KSR.tm.t_set_fr_inv() ####
+KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/tm.html#tm.f.t_set_fr_inv'> `int t_set_fr_inv(int)` </a> 
+
+#### KSR.tm.t_set_max_lifetime() ####
+KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/tm.html#tm.f.t_set_max_lifetime'> `int t_set_max_lifetime(int, int)` </a> 
+
+Docs declaration: `int t_set_max_lifetime(inv_lifetime, noninv_lifetime)`
+#### KSR.tm.t_set_no_e2e_cancel_reason() ####
+KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/tm.html#tm.f.t_set_no_e2e_cancel_reason'> `int t_set_no_e2e_cancel_reason(int)` </a> 
+
+Docs declaration: `int t_set_no_e2e_cancel_reason(0|1)`
+#### KSR.tm.t_set_retr() ####
+KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/tm.html#tm.f.t_set_retr'> `int t_set_retr(int, int)` </a> 
+
+Docs declaration: `int t_set_retr(retr_t1_interval, retr_t2_interval)`
+#### KSR.tm.t_uac_send() ####
+KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/tm.html#tm.f.t_uac_send'> `int t_uac_send(str, str, str, str, str, str)` </a> 
+
+Docs declaration: `int t_uac_send(method, ruri, nexthop, socket, headers,)`
+#### KSR.tm.t_use_uac_headers() ####
+KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/tm.html#tm.f.t_use_uac_headers'> `int t_use_uac_headers()` </a> 
+
+## tmx ##
+#### KSR.tmx.t_is_branch_route() ####
+KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/tmx.html#tmx.f.t_is_branch_route'> `int t_is_branch_route()` </a> 
+
+#### KSR.tmx.t_is_failure_route() ####
+KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/tmx.html#tmx.f.t_is_failure_route'> `int t_is_failure_route()` </a> 
+
+#### KSR.tmx.t_is_reply_route() ####
+KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/tmx.html#tmx.f.t_is_reply_route'> `int t_is_reply_route()` </a> 
+
+#### KSR.tmx.t_is_request_route() ####
+KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/tmx.html#tmx.f.t_is_request_route'> `int t_is_request_route()` </a> 
+
+#### KSR.tmx.t_precheck_trans() ####
+KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/tmx.html#tmx.f.t_precheck_trans'> `int t_precheck_trans()` </a> 
+
+## xlog ##
+#### KSR.xlog.xalert() ####
+KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/xlog.html#xlog.f.xalert'> `int xalert(str)` </a> 
+
+Docs declaration: `int xalert(format)`
+#### KSR.xlog.xcrit() ####
+KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/xlog.html#xlog.f.xcrit'> `int xcrit(str)` </a> 
+
+Docs declaration: `int xcrit(format)`
+#### KSR.xlog.xdbg() ####
+KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/xlog.html#xlog.f.xdbg'> `int xdbg(str)` </a> 
+
+Docs declaration: `int xdbg(format)`
+#### KSR.xlog.xerr() ####
+KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/xlog.html#xlog.f.xerr'> `int xerr(str)` </a> 
+
+Docs declaration: `int xerr(format)`
+#### KSR.xlog.xinfo() ####
+KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/xlog.html#xlog.f.xinfo'> `int xinfo(str)` </a> 
+
+Docs declaration: `int xinfo(format)`
+#### KSR.xlog.xlog() ####
+KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/xlog.html#xlog.f.xlog'> `int xlog(str, str)` </a> 
+
+Docs declaration: `int xlog([ [facility,] level,] format)`
+#### KSR.xlog.xnotice() ####
+KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/xlog.html#xlog.f.xnotice'> `int xnotice(str)` </a> 
+
+Docs declaration: `int xnotice(format)`
+#### KSR.xlog.xwarn() ####
+KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/xlog.html#xlog.f.xwarn'> `int xwarn(str)` </a> 
+
+Docs declaration: `int xwarn(format)`

--- a/kamailio-kemi-framework/mkdocs.yml
+++ b/kamailio-kemi-framework/mkdocs.yml
@@ -6,6 +6,6 @@ pages:
     - 'KEMI Interpreters': 'kemi.md'
     - 'Core Functions': 'core.md'
     - 'PV And Special Functions': 'kemimods.md'
-    - 'Acc Module Functions': 'acc.md'
+    - 'Module Functions': 'modules.md'
     - 'Support': 'support.md'
     - 'Contributions': 'contributions.md'

--- a/kamailio-kemi-framework/tools/generate_function_list.py
+++ b/kamailio-kemi-framework/tools/generate_function_list.py
@@ -1,0 +1,194 @@
+# This file generates the modules.md content
+# This file should be run in an environment where there is one, and only one, Kamailio install built from source
+import os, json, sys
+
+
+class ModuleDocGenerator(object):
+    PATH_GENERATED_JSON = "./generated_functions.json"
+    PATH_GENERATED_MARKDOWN = "../docs/modules.md"
+    # A source file in the tm module
+    SEARCH_DOCS_TM_FILE = "tm_load.c"
+
+    # Contains the output until it should be written to disk
+    markdown_string = ""
+    path_docs = ""
+
+    def execute(self):
+        path_kamctl = self.find("kamctl", "/")
+
+        # Obtain the KEMI function list through KAMCTL RPC
+        failed = os.system(path_kamctl + " rpc app_python.api_list > " + self.PATH_GENERATED_JSON)
+
+        if failed != 0:
+            print "ERR: Failed to execute KAMCTL"
+            exit()
+
+        functions_raw = json.load(open(self.PATH_GENERATED_JSON))
+
+        # Validate that we got some methods back. 155 is an arbitrary large number.
+        if functions_raw["result"]["msize"] < 155:
+            print "ERR: Invalid JSON RPC response"
+            exit()
+
+        functions_parsed = self.parse_function_list(functions_raw["result"]["methods"])
+        self.output_markdown(functions_parsed)
+
+        print "Markdown doc created successfully at " + self.PATH_GENERATED_MARKDOWN
+
+    def find(self, name, path):
+        for root, dirs, files in os.walk(path):
+            if name in files:
+                return os.path.join(root, name)
+
+    def parse_function_list(self, functions):
+        data = {}
+
+        for elem in functions:
+            props = elem["func"]
+            module = props["module"]
+
+            # The core and hdr submodule are documented in a different section
+            # TODO: What about the pvx module?
+            if module == "" or module == "hdr":
+                continue
+
+            if module not in data:
+                data[module] = []
+
+            data[module].append({"name": props["name"], "return": props["ret"], "params": props["params"]})
+
+        return data
+
+    def output_markdown(self, data):
+        self.markdown_header()
+
+        for key in sorted(data):
+            methods = data[key]
+            methods = sorted(methods, key = lambda k: k['name'])
+
+            self.markdown_section_heading(key)
+            self.markdown_section_content(key, methods)
+            self.markdown_write()
+
+        return True
+
+    def markdown_header(self):
+        self.markdown_string += "<!-- This file is auto-generated. Any manual modifications will be deleted -->\n"'' \
+        # TODO: Move the below markdown to a file in ../docs/modules/something.md
+        self.markdown_string += "# KEMI Module Functions #\n"
+        self.markdown_string += "The following sections lists all exported KEMI functions. More information regarding the function can be found by clicking the KEMI declaration which will take you the original modules documentation. \n"
+        return True
+
+    def markdown_section_heading(self, heading):
+        self.markdown_string += "## " + heading + " ##\n"
+        # TODO: Lookup if a file such as ../docs/modules/module.header.md exists and if so inject the markdown here
+        return True
+
+    def markdown_section_content(self, module, methods):
+        module_prefix = module + "."
+
+        for value in methods:
+            self.markdown_string += "#### KSR." + module_prefix + value["name"] + "() ####\n"
+
+            # Sanitize the return values
+            if value["return"] == "none":
+                return_value = "void"
+            else:
+                return_value = value["return"]
+
+            # Sanitize the parameter values
+            if value["params"] == "none":
+                params_value = ""
+            else:
+                params_value = value["params"]
+
+            docs_params = self.generate_param_definitions(params_value, module, value["name"])
+
+            # Generate the output string for the markdown page
+            self.markdown_string += "KEMI declaration: " "<a target='_blank' href='/docs/modules/devel/modules/" + module + ".html#" \
+                                    + module + ".f." + value["name"] + "'> `" + return_value + " " + value["name"] \
+                                    + "(" + params_value + ")` </a> \n\n"
+
+            # If we found a definition in the Docs let's present it as well
+            if params_value != docs_params:
+                self.markdown_string += "Docs declaration: `" + return_value + " " + value[
+                    "name"] + "(" + docs_params + ")`\n"
+
+            # TODO: Lookup if a file such as ../docs/modules/module.function.md exists and if so inject the markdown here
+        return True
+
+    def markdown_write(self):
+        f = open(self.PATH_GENERATED_MARKDOWN, "w")
+        f.write(self.markdown_string)
+        f.close()
+        return True
+
+    def generate_param_definitions(self, params_kemi, module, function):
+        if params_kemi == "":
+            return ""
+
+        # print params_kemi, module, function
+        params_original = self.find_function_parameters(module, function)
+
+        if params_original is None:
+            return params_kemi
+
+        # Remove redundant information
+        if params_original == "str" or params_original == "str" or params_original == "int" or params_original == "integer" or params_original == "param":
+            return ""
+
+        return params_original
+
+    def find_function_parameters(self, module, function):
+        path_modules = self.locate_docs_path()
+        path_readme = path_modules + module + "/README"
+
+        if not os.path.isfile(path_readme):
+            print "ERR: Could not find README for module: " + module
+            return None
+
+        with open(path_readme) as f:
+            content = f.readlines()
+
+        match = False
+
+        for line in content:
+            if line.find(function + "(") >= 0:
+                match = True
+                break
+            elif line.find(function + " (") >= 0:
+                match = True
+                break
+
+        if not match:
+            print "ERR: Could not find definition for function: " + module + "." + function
+            return None
+
+        # Get all content between parenthesises
+        params = line[line.find("(") + 1:line.find(")")]
+        if params == "":
+            return None
+
+        return params
+
+    def locate_docs_path(self):
+        if self.path_docs == "":
+            # We look for a file in the Kamailio source and work our way backwards from there
+            path = self.find(self.SEARCH_DOCS_TM_FILE, "/")
+            if path:
+                strip_path = "tm/" + self.SEARCH_DOCS_TM_FILE
+                path = path[:-len(strip_path)]
+                self.path_docs = path
+                return path
+            else:
+                print "ERR: Could not find the path to the Kamailio source"
+                exit()
+        else:
+            return self.path_docs
+
+
+if __name__ == "__main__":
+    reload(sys)
+    sys.setdefaultencoding('utf8')
+    fgen = ModuleDocGenerator()
+    fgen.execute()


### PR DESCRIPTION
- Documentation for exported KEMI functions was added for all modules except the Core/HDR submodules as they are already added. Where possible a declaration from the original modules docs is show as well.
