### PR TITLE
 kamailio-kemi-framework: All modules documented

### DIFF
--- a/kamailio-kemi-framework/docs/core.md
+++ b/kamailio-kemi-framework/docs/core.md
@@ -33,7 +33,7 @@ Write a log message to ERROR level.
 
 Write a log message to INFO level.
 
-### oid KSR.log(...) ###
+### void KSR.log(...) ###
 
 `void KSR.log("level", "msg")`
 

--- a/kamailio-kemi-framework/docs/extra.css
+++ b/kamailio-kemi-framework/docs/extra.css
@@ -14,6 +14,15 @@
 .wy-side-nav-search {
 	background: #222c32;
 }
+
 .rst-versions {
 	border-top:solid 10px #222c32;
+}
+
+.wy-menu-vertical a {
+    color: #f1f1f1
+}
+
+li.current a {
+    color: #212121
 }

--- a/kamailio-kemi-framework/docs/index.md
+++ b/kamailio-kemi-framework/docs/index.md
@@ -3,6 +3,8 @@
 ```
 Author: Daniel-Constantin Mierla (miconda@gmail.com)
 
+Contributors: Samuel Förnes
+
 Support: <sr-users@lists.kamailio.org>
 ```
 
@@ -63,7 +65,7 @@ With KEMI routing script, the `kamailio.cfg` keeps only the parts with:
 All of these parts are evaluated only once at startup. Many of the global and module parameters can be changed at
 runtime via `RPC` commands.
 
-The KEMI comes in the picture by allowing that the equivalend of routing blocks to be written in a different scripting
+The KEMI comes in the picture by allowing the equivalent of routing blocks to be written in a different scripting
 language. In other words, the routing blocks are now functions written in a KEMI supported scripting language.
 
 For each new KEMI supported scripting language a module has to be developed for Kamailio, this module linking

--- a/kamailio-kemi-framework/docs/modules.md
+++ b/kamailio-kemi-framework/docs/modules.md
@@ -1,436 +1,1470 @@
 <!-- This file is auto-generated. Any manual modifications will be deleted -->
 # KEMI Module Functions #
 The following sections lists all exported KEMI functions. More information regarding the function can be found by clicking the KEMI declaration which will take you the original modules documentation. 
+## acc ##
+#### KSR.acc.acc_db_request() ####
+<a target='_blank' href='/docs/modules/devel/modules/acc.html#acc.f.acc_db_request'> `int acc_db_request(str "comment", str "dbtable")` </a> 
+
+#### KSR.acc.acc_log_request() ####
+<a target='_blank' href='/docs/modules/devel/modules/acc.html#acc.f.acc_log_request'> `int acc_log_request(str "comment")` </a> 
+
+#### KSR.acc.acc_request() ####
+<a target='_blank' href='/docs/modules/devel/modules/acc.html#acc.f.acc_request'> `int acc_request(str "comment", str "dbtable")` </a> 
+
+## alias_db ##
+#### KSR.alias_db.lookup() ####
+<a target='_blank' href='/docs/modules/devel/modules/alias_db.html#alias_db.f.lookup'> `int lookup(str "stable")` </a> 
+
+#### KSR.alias_db.lookup_ex() ####
+<a target='_blank' href='/docs/modules/devel/modules/alias_db.html#alias_db.f.lookup_ex'> `int lookup_ex(str "stable", str "sflags")` </a> 
+
+## app_jsdt ##
+#### KSR.app_jsdt.dofile() ####
+<a target='_blank' href='/docs/modules/devel/modules/app_jsdt.html#app_jsdt.f.dofile'> `int dofile(str "script")` </a> 
+
+#### KSR.app_jsdt.dostring() ####
+<a target='_blank' href='/docs/modules/devel/modules/app_jsdt.html#app_jsdt.f.dostring'> `int dostring(str "script")` </a> 
+
+#### KSR.app_jsdt.run() ####
+<a target='_blank' href='/docs/modules/devel/modules/app_jsdt.html#app_jsdt.f.run'> `int run(str "func")` </a> 
+
+#### KSR.app_jsdt.run_p1() ####
+<a target='_blank' href='/docs/modules/devel/modules/app_jsdt.html#app_jsdt.f.run_p1'> `int run_p1(str "func", str "p1")` </a> 
+
+#### KSR.app_jsdt.run_p2() ####
+<a target='_blank' href='/docs/modules/devel/modules/app_jsdt.html#app_jsdt.f.run_p2'> `int run_p2(str "func", str "p1", str "p2")` </a> 
+
+#### KSR.app_jsdt.run_p3() ####
+<a target='_blank' href='/docs/modules/devel/modules/app_jsdt.html#app_jsdt.f.run_p3'> `int run_p3(str "func", str "p1", str "p2", str "p3")` </a> 
+
+#### KSR.app_jsdt.runstring() ####
+<a target='_blank' href='/docs/modules/devel/modules/app_jsdt.html#app_jsdt.f.runstring'> `int runstring(str "script")` </a> 
+
+## app_lua ##
+#### KSR.app_lua.dofile() ####
+<a target='_blank' href='/docs/modules/devel/modules/app_lua.html#app_lua.f.dofile'> `int dofile(str "script")` </a> 
+
+#### KSR.app_lua.dostring() ####
+<a target='_blank' href='/docs/modules/devel/modules/app_lua.html#app_lua.f.dostring'> `int dostring(str "script")` </a> 
+
+#### KSR.app_lua.run() ####
+<a target='_blank' href='/docs/modules/devel/modules/app_lua.html#app_lua.f.run'> `int run(str "func")` </a> 
+
+#### KSR.app_lua.run_p1() ####
+<a target='_blank' href='/docs/modules/devel/modules/app_lua.html#app_lua.f.run_p1'> `int run_p1(str "func", str "p1")` </a> 
+
+#### KSR.app_lua.run_p2() ####
+<a target='_blank' href='/docs/modules/devel/modules/app_lua.html#app_lua.f.run_p2'> `int run_p2(str "func", str "p1", str "p2")` </a> 
+
+#### KSR.app_lua.run_p3() ####
+<a target='_blank' href='/docs/modules/devel/modules/app_lua.html#app_lua.f.run_p3'> `int run_p3(str "func", str "p1", str "p2", str "p3")` </a> 
+
+#### KSR.app_lua.runstring() ####
+<a target='_blank' href='/docs/modules/devel/modules/app_lua.html#app_lua.f.runstring'> `int runstring(str "script")` </a> 
+
 ## app_python ##
 #### KSR.app_python.exec() ####
-KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/app_python.html#app_python.f.exec'> `int exec(str)` </a> 
+<a target='_blank' href='/docs/modules/devel/modules/app_python.html#app_python.f.exec'> `int exec(str "method")` </a> 
 
-Docs declaration: `int exec(method [, args])`
 #### KSR.app_python.exec_p1() ####
-KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/app_python.html#app_python.f.exec_p1'> `int exec_p1(str, str)` </a> 
+<a target='_blank' href='/docs/modules/devel/modules/app_python.html#app_python.f.exec_p1'> `int exec_p1(str "method", str "p1")` </a> 
+
+## app_sqlang ##
+#### KSR.app_sqlang.dofile() ####
+<a target='_blank' href='/docs/modules/devel/modules/app_sqlang.html#app_sqlang.f.dofile'> `int dofile(str "script")` </a> 
+
+#### KSR.app_sqlang.dostring() ####
+<a target='_blank' href='/docs/modules/devel/modules/app_sqlang.html#app_sqlang.f.dostring'> `int dostring(str "script")` </a> 
+
+#### KSR.app_sqlang.run() ####
+<a target='_blank' href='/docs/modules/devel/modules/app_sqlang.html#app_sqlang.f.run'> `int run(str "func")` </a> 
+
+#### KSR.app_sqlang.run_p1() ####
+<a target='_blank' href='/docs/modules/devel/modules/app_sqlang.html#app_sqlang.f.run_p1'> `int run_p1(str "func", str "p1")` </a> 
+
+#### KSR.app_sqlang.run_p2() ####
+<a target='_blank' href='/docs/modules/devel/modules/app_sqlang.html#app_sqlang.f.run_p2'> `int run_p2(str "func", str "p1", str "p2")` </a> 
+
+#### KSR.app_sqlang.run_p3() ####
+<a target='_blank' href='/docs/modules/devel/modules/app_sqlang.html#app_sqlang.f.run_p3'> `int run_p3(str "func", str "p1", str "p2", str "p3")` </a> 
+
+#### KSR.app_sqlang.runstring() ####
+<a target='_blank' href='/docs/modules/devel/modules/app_sqlang.html#app_sqlang.f.runstring'> `int runstring(str "script")` </a> 
+
+## async ##
+#### KSR.async.route() ####
+<a target='_blank' href='/docs/modules/devel/modules/async.html#async.f.route'> `int route(str "rn", int s)` </a> 
+
+#### KSR.async.task_route() ####
+<a target='_blank' href='/docs/modules/devel/modules/async.html#async.f.task_route'> `int task_route(str "rn")` </a> 
+
+## auth ##
+#### KSR.auth.auth_challenge() ####
+<a target='_blank' href='/docs/modules/devel/modules/auth.html#auth.f.auth_challenge'> `int auth_challenge(str "realm", int flags)` </a> 
+
+#### KSR.auth.consume_credentials() ####
+<a target='_blank' href='/docs/modules/devel/modules/auth.html#auth.f.consume_credentials'> `int consume_credentials()` </a> 
+
+#### KSR.auth.has_credentials() ####
+<a target='_blank' href='/docs/modules/devel/modules/auth.html#auth.f.has_credentials'> `int has_credentials(str "srealm")` </a> 
+
+#### KSR.auth.pv_auth_check() ####
+<a target='_blank' href='/docs/modules/devel/modules/auth.html#auth.f.pv_auth_check'> `int pv_auth_check(str "srealm", str "spasswd", int vflags, int vchecks)` </a> 
+
+## auth_db ##
+#### KSR.auth_db.auth_check() ####
+<a target='_blank' href='/docs/modules/devel/modules/auth_db.html#auth_db.f.auth_check'> `int auth_check(str "srealm", str "stable", int iflags)` </a> 
+
+#### KSR.auth_db.is_subscriber() ####
+<a target='_blank' href='/docs/modules/devel/modules/auth_db.html#auth_db.f.is_subscriber'> `int is_subscriber(str "suri", str "stable", int iflags)` </a> 
+
+## auth_xkeys ##
+#### KSR.auth_xkeys.auth_xkeys_add() ####
+<a target='_blank' href='/docs/modules/devel/modules/auth_xkeys.html#auth_xkeys.f.auth_xkeys_add'> `int auth_xkeys_add(str "shdr", str "skey", str "salg", str "sdata")` </a> 
+
+#### KSR.auth_xkeys.auth_xkeys_check() ####
+<a target='_blank' href='/docs/modules/devel/modules/auth_xkeys.html#auth_xkeys.f.auth_xkeys_check'> `int auth_xkeys_check(str "shdr", str "skey", str "salg", str "sdata")` </a> 
+
+## call_control ##
+#### KSR.call_control.call_control() ####
+<a target='_blank' href='/docs/modules/devel/modules/call_control.html#call_control.f.call_control'> `int call_control()` </a> 
+
+## cfgutils ##
+#### KSR.cfgutils.abort() ####
+<a target='_blank' href='/docs/modules/devel/modules/cfgutils.html#cfgutils.f.abort'> `int abort()` </a> 
+
+#### KSR.cfgutils.core_hash() ####
+<a target='_blank' href='/docs/modules/devel/modules/cfgutils.html#cfgutils.f.core_hash'> `int core_hash(str "s1", str "s2", int sz)` </a> 
+
+#### KSR.cfgutils.lock() ####
+<a target='_blank' href='/docs/modules/devel/modules/cfgutils.html#cfgutils.f.lock'> `int lock(str "lkey")` </a> 
+
+#### KSR.cfgutils.pkg_status() ####
+<a target='_blank' href='/docs/modules/devel/modules/cfgutils.html#cfgutils.f.pkg_status'> `int pkg_status()` </a> 
+
+#### KSR.cfgutils.pkg_summary() ####
+<a target='_blank' href='/docs/modules/devel/modules/cfgutils.html#cfgutils.f.pkg_summary'> `int pkg_summary()` </a> 
+
+#### KSR.cfgutils.rand_event() ####
+<a target='_blank' href='/docs/modules/devel/modules/cfgutils.html#cfgutils.f.rand_event'> `int rand_event()` </a> 
+
+#### KSR.cfgutils.rand_get_prob() ####
+<a target='_blank' href='/docs/modules/devel/modules/cfgutils.html#cfgutils.f.rand_get_prob'> `int rand_get_prob()` </a> 
+
+#### KSR.cfgutils.rand_reset_prob() ####
+<a target='_blank' href='/docs/modules/devel/modules/cfgutils.html#cfgutils.f.rand_reset_prob'> `int rand_reset_prob()` </a> 
+
+#### KSR.cfgutils.rand_set_prob() ####
+<a target='_blank' href='/docs/modules/devel/modules/cfgutils.html#cfgutils.f.rand_set_prob'> `int rand_set_prob(int percent_par)` </a> 
+
+#### KSR.cfgutils.shm_status() ####
+<a target='_blank' href='/docs/modules/devel/modules/cfgutils.html#cfgutils.f.shm_status'> `int shm_status()` </a> 
+
+#### KSR.cfgutils.shm_summary() ####
+<a target='_blank' href='/docs/modules/devel/modules/cfgutils.html#cfgutils.f.shm_summary'> `int shm_summary()` </a> 
+
+#### KSR.cfgutils.trylock() ####
+<a target='_blank' href='/docs/modules/devel/modules/cfgutils.html#cfgutils.f.trylock'> `int trylock(str "lkey")` </a> 
+
+#### KSR.cfgutils.unlock() ####
+<a target='_blank' href='/docs/modules/devel/modules/cfgutils.html#cfgutils.f.unlock'> `int unlock(str "lkey")` </a> 
 
 ## corex ##
 #### KSR.corex.append_branch() ####
-KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/corex.html#corex.f.append_branch'> `int append_branch()` </a> 
+<a target='_blank' href='/docs/modules/devel/modules/corex.html#corex.f.append_branch'> `int append_branch()` </a> 
 
 #### KSR.corex.append_branch_uri() ####
-KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/corex.html#corex.f.append_branch_uri'> `int append_branch_uri(str)` </a> 
+<a target='_blank' href='/docs/modules/devel/modules/corex.html#corex.f.append_branch_uri'> `int append_branch_uri(str "uri")` </a> 
 
 #### KSR.corex.append_branch_uri_q() ####
-KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/corex.html#corex.f.append_branch_uri_q'> `int append_branch_uri_q(str, str)` </a> 
+<a target='_blank' href='/docs/modules/devel/modules/corex.html#corex.f.append_branch_uri_q'> `int append_branch_uri_q(str "uri", str "q")` </a> 
+
+## debugger ##
+#### KSR.debugger.dbg_pv_dump() ####
+<a target='_blank' href='/docs/modules/devel/modules/debugger.html#debugger.f.dbg_pv_dump'> `int dbg_pv_dump()` </a> 
+
+#### KSR.debugger.dbg_pv_dump_ex() ####
+<a target='_blank' href='/docs/modules/devel/modules/debugger.html#debugger.f.dbg_pv_dump_ex'> `int dbg_pv_dump_ex(int mask, int level)` </a> 
+
+## dialog ##
+#### KSR.dialog.dlg_bye() ####
+<a target='_blank' href='/docs/modules/devel/modules/dialog.html#dialog.f.dlg_bye'> `int dlg_bye(str "side")` </a> 
+
+#### KSR.dialog.dlg_get() ####
+<a target='_blank' href='/docs/modules/devel/modules/dialog.html#dialog.f.dlg_get'> `int dlg_get(str "sc", str "sf", str "st")` </a> 
+
+#### KSR.dialog.dlg_isflagset() ####
+<a target='_blank' href='/docs/modules/devel/modules/dialog.html#dialog.f.dlg_isflagset'> `int dlg_isflagset(int val)` </a> 
+
+#### KSR.dialog.dlg_manage() ####
+<a target='_blank' href='/docs/modules/devel/modules/dialog.html#dialog.f.dlg_manage'> `int dlg_manage()` </a> 
+
+#### KSR.dialog.dlg_resetflag() ####
+<a target='_blank' href='/docs/modules/devel/modules/dialog.html#dialog.f.dlg_resetflag'> `int dlg_resetflag(int val)` </a> 
+
+#### KSR.dialog.dlg_set_property() ####
+<a target='_blank' href='/docs/modules/devel/modules/dialog.html#dialog.f.dlg_set_property'> `int dlg_set_property(str "pval")` </a> 
+
+#### KSR.dialog.dlg_set_timeout() ####
+<a target='_blank' href='/docs/modules/devel/modules/dialog.html#dialog.f.dlg_set_timeout'> `int dlg_set_timeout(int to)` </a> 
+
+#### KSR.dialog.dlg_set_timeout_id() ####
+<a target='_blank' href='/docs/modules/devel/modules/dialog.html#dialog.f.dlg_set_timeout_id'> `int dlg_set_timeout_id(int to, int he, int hi)` </a> 
+
+#### KSR.dialog.dlg_setflag() ####
+<a target='_blank' href='/docs/modules/devel/modules/dialog.html#dialog.f.dlg_setflag'> `int dlg_setflag(int val)` </a> 
+
+#### KSR.dialog.get_profile_size() ####
+<a target='_blank' href='/docs/modules/devel/modules/dialog.html#dialog.f.get_profile_size'> `int get_profile_size(str "sprofile", str "svalue", str "spv")` </a> 
+
+#### KSR.dialog.get_profile_size_static() ####
+<a target='_blank' href='/docs/modules/devel/modules/dialog.html#dialog.f.get_profile_size_static'> `int get_profile_size_static(str "sprofile", str "spv")` </a> 
+
+#### KSR.dialog.is_in_profile() ####
+<a target='_blank' href='/docs/modules/devel/modules/dialog.html#dialog.f.is_in_profile'> `int is_in_profile(str "sprofile", str "svalue")` </a> 
+
+#### KSR.dialog.is_in_profile_static() ####
+<a target='_blank' href='/docs/modules/devel/modules/dialog.html#dialog.f.is_in_profile_static'> `int is_in_profile_static(str "sprofile")` </a> 
+
+#### KSR.dialog.is_known_dlg() ####
+<a target='_blank' href='/docs/modules/devel/modules/dialog.html#dialog.f.is_known_dlg'> `int is_known_dlg()` </a> 
+
+#### KSR.dialog.set_dlg_profile() ####
+<a target='_blank' href='/docs/modules/devel/modules/dialog.html#dialog.f.set_dlg_profile'> `int set_dlg_profile(str "sprofile", str "svalue")` </a> 
+
+#### KSR.dialog.set_dlg_profile_static() ####
+<a target='_blank' href='/docs/modules/devel/modules/dialog.html#dialog.f.set_dlg_profile_static'> `int set_dlg_profile_static(str "sprofile")` </a> 
+
+#### KSR.dialog.unset_dlg_profile() ####
+<a target='_blank' href='/docs/modules/devel/modules/dialog.html#dialog.f.unset_dlg_profile'> `int unset_dlg_profile(str "sprofile", str "svalue")` </a> 
+
+#### KSR.dialog.unset_dlg_profile_static() ####
+<a target='_blank' href='/docs/modules/devel/modules/dialog.html#dialog.f.unset_dlg_profile_static'> `int unset_dlg_profile_static(str "sprofile")` </a> 
+
+## dialplan ##
+#### KSR.dialplan.dp_match() ####
+<a target='_blank' href='/docs/modules/devel/modules/dialplan.html#dialplan.f.dp_match'> `int dp_match(int dpid, str "src")` </a> 
+
+#### KSR.dialplan.dp_replace() ####
+<a target='_blank' href='/docs/modules/devel/modules/dialplan.html#dialplan.f.dp_replace'> `int dp_replace(int dpid, str "src", str "dst")` </a> 
+
+## dispatcher ##
+#### KSR.dispatcher.ds_next_domain() ####
+<a target='_blank' href='/docs/modules/devel/modules/dispatcher.html#dispatcher.f.ds_next_domain'> `int ds_next_domain()` </a> 
+
+#### KSR.dispatcher.ds_next_dst() ####
+<a target='_blank' href='/docs/modules/devel/modules/dispatcher.html#dispatcher.f.ds_next_dst'> `int ds_next_dst()` </a> 
+
+#### KSR.dispatcher.ds_select() ####
+<a target='_blank' href='/docs/modules/devel/modules/dispatcher.html#dispatcher.f.ds_select'> `int ds_select(int set, int alg)` </a> 
+
+#### KSR.dispatcher.ds_select_domain() ####
+<a target='_blank' href='/docs/modules/devel/modules/dispatcher.html#dispatcher.f.ds_select_domain'> `int ds_select_domain(int set, int alg)` </a> 
+
+#### KSR.dispatcher.ds_select_domain_limit() ####
+<a target='_blank' href='/docs/modules/devel/modules/dispatcher.html#dispatcher.f.ds_select_domain_limit'> `int ds_select_domain_limit(int set, int alg, int limit)` </a> 
+
+#### KSR.dispatcher.ds_select_dst() ####
+<a target='_blank' href='/docs/modules/devel/modules/dispatcher.html#dispatcher.f.ds_select_dst'> `int ds_select_dst(int set, int alg)` </a> 
+
+#### KSR.dispatcher.ds_select_dst_limit() ####
+<a target='_blank' href='/docs/modules/devel/modules/dispatcher.html#dispatcher.f.ds_select_dst_limit'> `int ds_select_dst_limit(int set, int alg, int limit)` </a> 
+
+#### KSR.dispatcher.ds_select_limit() ####
+<a target='_blank' href='/docs/modules/devel/modules/dispatcher.html#dispatcher.f.ds_select_limit'> `int ds_select_limit(int set, int alg, int limit)` </a> 
+
+## diversion ##
+#### KSR.diversion.add_diversion() ####
+<a target='_blank' href='/docs/modules/devel/modules/diversion.html#diversion.f.add_diversion'> `int add_diversion(str "reason")` </a> 
+
+#### KSR.diversion.add_diversion_uri() ####
+<a target='_blank' href='/docs/modules/devel/modules/diversion.html#diversion.f.add_diversion_uri'> `int add_diversion_uri(str "reason", str "uri")` </a> 
+
+## domain ##
+#### KSR.domain.is_domain_local() ####
+<a target='_blank' href='/docs/modules/devel/modules/domain.html#domain.f.is_domain_local'> `int is_domain_local(str "sdomain")` </a> 
+
+#### KSR.domain.is_from_local() ####
+<a target='_blank' href='/docs/modules/devel/modules/domain.html#domain.f.is_from_local'> `int is_from_local()` </a> 
+
+#### KSR.domain.is_uri_host_local() ####
+<a target='_blank' href='/docs/modules/devel/modules/domain.html#domain.f.is_uri_host_local'> `int is_uri_host_local()` </a> 
+
+#### KSR.domain.lookup_domain() ####
+<a target='_blank' href='/docs/modules/devel/modules/domain.html#domain.f.lookup_domain'> `int lookup_domain(str "_sdomain")` </a> 
+
+#### KSR.domain.lookup_domain_prefix() ####
+<a target='_blank' href='/docs/modules/devel/modules/domain.html#domain.f.lookup_domain_prefix'> `int lookup_domain_prefix(str "_sdomain", str "_sprefix")` </a> 
+
+## drouting ##
+#### KSR.drouting.do_routing() ####
+<a target='_blank' href='/docs/modules/devel/modules/drouting.html#drouting.f.do_routing'> `int do_routing(int grp_id)` </a> 
+
+#### KSR.drouting.do_routing_furi() ####
+<a target='_blank' href='/docs/modules/devel/modules/drouting.html#drouting.f.do_routing_furi'> `int do_routing_furi()` </a> 
+
+#### KSR.drouting.goes_to_gw() ####
+<a target='_blank' href='/docs/modules/devel/modules/drouting.html#drouting.f.goes_to_gw'> `int goes_to_gw()` </a> 
+
+#### KSR.drouting.goes_to_gw_type() ####
+<a target='_blank' href='/docs/modules/devel/modules/drouting.html#drouting.f.goes_to_gw_type'> `int goes_to_gw_type(int type)` </a> 
+
+#### KSR.drouting.is_from_gw() ####
+<a target='_blank' href='/docs/modules/devel/modules/drouting.html#drouting.f.is_from_gw'> `int is_from_gw()` </a> 
+
+#### KSR.drouting.is_from_gw_type() ####
+<a target='_blank' href='/docs/modules/devel/modules/drouting.html#drouting.f.is_from_gw_type'> `int is_from_gw_type(int type)` </a> 
+
+#### KSR.drouting.is_from_gw_type_flags() ####
+<a target='_blank' href='/docs/modules/devel/modules/drouting.html#drouting.f.is_from_gw_type_flags'> `int is_from_gw_type_flags(int type, int flags)` </a> 
+
+#### KSR.drouting.next_routing() ####
+<a target='_blank' href='/docs/modules/devel/modules/drouting.html#drouting.f.next_routing'> `int next_routing()` </a> 
+
+#### KSR.drouting.use_next_gw() ####
+<a target='_blank' href='/docs/modules/devel/modules/drouting.html#drouting.f.use_next_gw'> `int use_next_gw()` </a> 
+
+## enum ##
+#### KSR.enum.enum_i_query_suffix() ####
+<a target='_blank' href='/docs/modules/devel/modules/enum.html#enum.f.enum_i_query_suffix'> `int enum_i_query_suffix(str "vsuffix")` </a> 
+
+#### KSR.enum.enum_pv_query() ####
+<a target='_blank' href='/docs/modules/devel/modules/enum.html#enum.f.enum_pv_query'> `int enum_pv_query(str "ve164")` </a> 
+
+#### KSR.enum.enum_pv_query_suffix() ####
+<a target='_blank' href='/docs/modules/devel/modules/enum.html#enum.f.enum_pv_query_suffix'> `int enum_pv_query_suffix(str "ve164", str "vsuffix")` </a> 
+
+#### KSR.enum.enum_pv_query_suffix_service() ####
+<a target='_blank' href='/docs/modules/devel/modules/enum.html#enum.f.enum_pv_query_suffix_service'> `int enum_pv_query_suffix_service(str "ve164", str "vsuffix", str "vservice")` </a> 
+
+#### KSR.enum.enum_query() ####
+<a target='_blank' href='/docs/modules/devel/modules/enum.html#enum.f.enum_query'> `int enum_query()` </a> 
+
+#### KSR.enum.enum_query_suffix() ####
+<a target='_blank' href='/docs/modules/devel/modules/enum.html#enum.f.enum_query_suffix'> `int enum_query_suffix(str "vsuffix")` </a> 
+
+#### KSR.enum.enum_query_suffix_service() ####
+<a target='_blank' href='/docs/modules/devel/modules/enum.html#enum.f.enum_query_suffix_service'> `int enum_query_suffix_service(str "vsuffix", str "vservice")` </a> 
+
+#### KSR.enum.i_enum_query() ####
+<a target='_blank' href='/docs/modules/devel/modules/enum.html#enum.f.i_enum_query'> `int i_enum_query()` </a> 
+
+#### KSR.enum.i_enum_query_suffix_service() ####
+<a target='_blank' href='/docs/modules/devel/modules/enum.html#enum.f.i_enum_query_suffix_service'> `int i_enum_query_suffix_service(str "vsuffix", str "vservice")` </a> 
+
+#### KSR.enum.is_from_user_enum() ####
+<a target='_blank' href='/docs/modules/devel/modules/enum.html#enum.f.is_from_user_enum'> `int is_from_user_enum()` </a> 
+
+#### KSR.enum.is_from_user_enum_suffix() ####
+<a target='_blank' href='/docs/modules/devel/modules/enum.html#enum.f.is_from_user_enum_suffix'> `int is_from_user_enum_suffix(str "vsuffix")` </a> 
+
+#### KSR.enum.is_from_user_enum_suffix_service() ####
+<a target='_blank' href='/docs/modules/devel/modules/enum.html#enum.f.is_from_user_enum_suffix_service'> `int is_from_user_enum_suffix_service(str "vsuffix", str "vservice")` </a> 
+
+## evapi ##
+#### KSR.evapi.close() ####
+<a target='_blank' href='/docs/modules/devel/modules/evapi.html#evapi.f.close'> `int close()` </a> 
+
+#### KSR.evapi.relay() ####
+<a target='_blank' href='/docs/modules/devel/modules/evapi.html#evapi.f.relay'> `int relay(str "sdata")` </a> 
+
+#### KSR.evapi.relay_multicast() ####
+<a target='_blank' href='/docs/modules/devel/modules/evapi.html#evapi.f.relay_multicast'> `int relay_multicast(str "sdata", str "stag")` </a> 
+
+#### KSR.evapi.relay_unicast() ####
+<a target='_blank' href='/docs/modules/devel/modules/evapi.html#evapi.f.relay_unicast'> `int relay_unicast(str "sdata", str "stag")` </a> 
+
+#### KSR.evapi.set_tag() ####
+<a target='_blank' href='/docs/modules/devel/modules/evapi.html#evapi.f.set_tag'> `int set_tag(str "stag")` </a> 
+
+## exec ##
+#### KSR.exec.exec_avp() ####
+<a target='_blank' href='/docs/modules/devel/modules/exec.html#exec.f.exec_avp'> `int exec_avp(str "cmd")` </a> 
+
+#### KSR.exec.exec_dset() ####
+<a target='_blank' href='/docs/modules/devel/modules/exec.html#exec.f.exec_dset'> `int exec_dset(str "cmd")` </a> 
+
+#### KSR.exec.exec_msg() ####
+<a target='_blank' href='/docs/modules/devel/modules/exec.html#exec.f.exec_msg'> `int exec_msg(str "cmd")` </a> 
+
+## geoip ##
+#### KSR.geoip.match() ####
+<a target='_blank' href='/docs/modules/devel/modules/geoip.html#geoip.f.match'> `int match(str "tomatch", str "pvclass")` </a> 
+
+## geoip2 ##
+#### KSR.geoip2.match() ####
+<a target='_blank' href='/docs/modules/devel/modules/geoip2.html#geoip2.f.match'> `int match(str "tomatch", str "pvclass")` </a> 
+
+## htable ##
+#### KSR.htable.sht_iterator_end() ####
+<a target='_blank' href='/docs/modules/devel/modules/htable.html#htable.f.sht_iterator_end'> `int sht_iterator_end(str "iname")` </a> 
+
+#### KSR.htable.sht_iterator_next() ####
+<a target='_blank' href='/docs/modules/devel/modules/htable.html#htable.f.sht_iterator_next'> `int sht_iterator_next(str "iname")` </a> 
+
+#### KSR.htable.sht_iterator_start() ####
+<a target='_blank' href='/docs/modules/devel/modules/htable.html#htable.f.sht_iterator_start'> `int sht_iterator_start(str "iname", str "hname")` </a> 
+
+#### KSR.htable.sht_lock() ####
+<a target='_blank' href='/docs/modules/devel/modules/htable.html#htable.f.sht_lock'> `int sht_lock(str "htname", str "skey")` </a> 
+
+#### KSR.htable.sht_reset() ####
+<a target='_blank' href='/docs/modules/devel/modules/htable.html#htable.f.sht_reset'> `int sht_reset(str "hname")` </a> 
+
+#### KSR.htable.sht_unlock() ####
+<a target='_blank' href='/docs/modules/devel/modules/htable.html#htable.f.sht_unlock'> `int sht_unlock(str "htname", str "skey")` </a> 
+
+## imc ##
+#### KSR.imc.imc_manager() ####
+<a target='_blank' href='/docs/modules/devel/modules/imc.html#imc.f.imc_manager'> `int imc_manager()` </a> 
 
 ## jsonrpcs ##
 #### KSR.jsonrpcs.exec() ####
-KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/jsonrpcs.html#jsonrpcs.f.exec'> `int exec(str)` </a> 
+<a target='_blank' href='/docs/modules/devel/modules/jsonrpcs.html#jsonrpcs.f.exec'> `int exec(str "scmd")` </a> 
 
-Docs declaration: `int exec(cmd)`
+## keepalive ##
+#### KSR.keepalive.is_alive() ####
+<a target='_blank' href='/docs/modules/devel/modules/keepalive.html#keepalive.f.is_alive'> `int is_alive(str "dest")` </a> 
+
 ## kex ##
 #### KSR.kex.resetdebug() ####
-KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/kex.html#kex.f.resetdebug'> `int resetdebug(str, str)` </a> 
+<a target='_blank' href='/docs/modules/devel/modules/kex.html#kex.f.resetdebug'> `int resetdebug()` </a> 
 
 #### KSR.kex.setdebug() ####
-KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/kex.html#kex.f.setdebug'> `int setdebug(int)` </a> 
+<a target='_blank' href='/docs/modules/devel/modules/kex.html#kex.f.setdebug'> `int setdebug(int lval)` </a> 
 
-Docs declaration: `int setdebug(level)`
+## lcr ##
+#### KSR.lcr.defunct_gw() ####
+<a target='_blank' href='/docs/modules/devel/modules/lcr.html#lcr.f.defunct_gw'> `int defunct_gw(int defunct_period)` </a> 
+
+#### KSR.lcr.from_any_gw() ####
+<a target='_blank' href='/docs/modules/devel/modules/lcr.html#lcr.f.from_any_gw'> `int from_any_gw()` </a> 
+
+#### KSR.lcr.from_any_gw_addr() ####
+<a target='_blank' href='/docs/modules/devel/modules/lcr.html#lcr.f.from_any_gw_addr'> `int from_any_gw_addr(str "addr_str", int transport)` </a> 
+
+#### KSR.lcr.from_gw() ####
+<a target='_blank' href='/docs/modules/devel/modules/lcr.html#lcr.f.from_gw'> `int from_gw(int lcr_id)` </a> 
+
+#### KSR.lcr.from_gw_addr() ####
+<a target='_blank' href='/docs/modules/devel/modules/lcr.html#lcr.f.from_gw_addr'> `int from_gw_addr(int lcr_id, str "addr_str", int transport)` </a> 
+
+#### KSR.lcr.inactivate_gw() ####
+<a target='_blank' href='/docs/modules/devel/modules/lcr.html#lcr.f.inactivate_gw'> `int inactivate_gw()` </a> 
+
+#### KSR.lcr.load_gws() ####
+<a target='_blank' href='/docs/modules/devel/modules/lcr.html#lcr.f.load_gws'> `int load_gws(int lcr_id)` </a> 
+
+#### KSR.lcr.load_gws_furi() ####
+<a target='_blank' href='/docs/modules/devel/modules/lcr.html#lcr.f.load_gws_furi'> `int load_gws_furi(int lcr_id, str "ruri_user", str "from_uri")` </a> 
+
+#### KSR.lcr.load_gws_ruser() ####
+<a target='_blank' href='/docs/modules/devel/modules/lcr.html#lcr.f.load_gws_ruser'> `int load_gws_ruser(int lcr_id, str "ruri_user")` </a> 
+
+#### KSR.lcr.next_gw() ####
+<a target='_blank' href='/docs/modules/devel/modules/lcr.html#lcr.f.next_gw'> `int next_gw()` </a> 
+
+#### KSR.lcr.to_any_gw() ####
+<a target='_blank' href='/docs/modules/devel/modules/lcr.html#lcr.f.to_any_gw'> `int to_any_gw()` </a> 
+
+#### KSR.lcr.to_any_gw_addr() ####
+<a target='_blank' href='/docs/modules/devel/modules/lcr.html#lcr.f.to_any_gw_addr'> `int to_any_gw_addr(str "addr_str", int transport)` </a> 
+
+#### KSR.lcr.to_gw() ####
+<a target='_blank' href='/docs/modules/devel/modules/lcr.html#lcr.f.to_gw'> `int to_gw(int lcr_id)` </a> 
+
+#### KSR.lcr.to_gw_addr() ####
+<a target='_blank' href='/docs/modules/devel/modules/lcr.html#lcr.f.to_gw_addr'> `int to_gw_addr(int lcr_id, str "addr_str", int transport)` </a> 
+
+## log_custom ##
+#### KSR.log_custom.log_udp() ####
+<a target='_blank' href='/docs/modules/devel/modules/log_custom.html#log_custom.f.log_udp'> `int log_udp(str "txt")` </a> 
+
 ## maxfwd ##
 #### KSR.maxfwd.process_maxfwd() ####
-KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/maxfwd.html#maxfwd.f.process_maxfwd'> `int process_maxfwd(int)` </a> 
+<a target='_blank' href='/docs/modules/devel/modules/maxfwd.html#maxfwd.f.process_maxfwd'> `int process_maxfwd(int limit)` </a> 
 
-Docs declaration: `int process_maxfwd(max_value)`
+## mqueue ##
+#### KSR.mqueue.mq_add() ####
+<a target='_blank' href='/docs/modules/devel/modules/mqueue.html#mqueue.f.mq_add'> `int mq_add(str "mq", str "key", str "val")` </a> 
+
+#### KSR.mqueue.mq_fetch() ####
+<a target='_blank' href='/docs/modules/devel/modules/mqueue.html#mqueue.f.mq_fetch'> `int mq_fetch(str "mq")` </a> 
+
+#### KSR.mqueue.mq_pv_free() ####
+<a target='_blank' href='/docs/modules/devel/modules/mqueue.html#mqueue.f.mq_pv_free'> `int mq_pv_free(str "mq")` </a> 
+
+#### KSR.mqueue.mq_size() ####
+<a target='_blank' href='/docs/modules/devel/modules/mqueue.html#mqueue.f.mq_size'> `int mq_size(str "mq")` </a> 
+
+## msrp ##
+#### KSR.msrp.cmap_lookup() ####
+<a target='_blank' href='/docs/modules/devel/modules/msrp.html#msrp.f.cmap_lookup'> `int cmap_lookup()` </a> 
+
+#### KSR.msrp.cmap_save() ####
+<a target='_blank' href='/docs/modules/devel/modules/msrp.html#msrp.f.cmap_save'> `int cmap_save()` </a> 
+
+#### KSR.msrp.is_reply() ####
+<a target='_blank' href='/docs/modules/devel/modules/msrp.html#msrp.f.is_reply'> `int is_reply()` </a> 
+
+#### KSR.msrp.is_request() ####
+<a target='_blank' href='/docs/modules/devel/modules/msrp.html#msrp.f.is_request'> `int is_request()` </a> 
+
+#### KSR.msrp.relay() ####
+<a target='_blank' href='/docs/modules/devel/modules/msrp.html#msrp.f.relay'> `int relay()` </a> 
+
+#### KSR.msrp.relay_flags() ####
+<a target='_blank' href='/docs/modules/devel/modules/msrp.html#msrp.f.relay_flags'> `int relay_flags(int rtflags)` </a> 
+
+#### KSR.msrp.reply() ####
+<a target='_blank' href='/docs/modules/devel/modules/msrp.html#msrp.f.reply'> `int reply(str "rcode", str "rtext", str "rhdrs")` </a> 
+
+#### KSR.msrp.reply_flags() ####
+<a target='_blank' href='/docs/modules/devel/modules/msrp.html#msrp.f.reply_flags'> `int reply_flags(int rtflags)` </a> 
+
+#### KSR.msrp.set_dst() ####
+<a target='_blank' href='/docs/modules/devel/modules/msrp.html#msrp.f.set_dst'> `int set_dst(str "rtaddr", str "rfsock")` </a> 
+
+## mtree ##
+#### KSR.mtree.mt_match() ####
+<a target='_blank' href='/docs/modules/devel/modules/mtree.html#mtree.f.mt_match'> `int mt_match(str "tname", str "tomatch", int mval)` </a> 
+
+## nathelper ##
+#### KSR.nathelper.add_contact_alias() ####
+<a target='_blank' href='/docs/modules/devel/modules/nathelper.html#nathelper.f.add_contact_alias'> `int add_contact_alias()` </a> 
+
+#### KSR.nathelper.add_contact_alias_addr() ####
+<a target='_blank' href='/docs/modules/devel/modules/nathelper.html#nathelper.f.add_contact_alias_addr'> `int add_contact_alias_addr(str "ip_str", str "port_str", str "proto_str")` </a> 
+
+#### KSR.nathelper.add_rcv_param() ####
+<a target='_blank' href='/docs/modules/devel/modules/nathelper.html#nathelper.f.add_rcv_param'> `int add_rcv_param(int hdr_param)` </a> 
+
+#### KSR.nathelper.fix_nated_contact() ####
+<a target='_blank' href='/docs/modules/devel/modules/nathelper.html#nathelper.f.fix_nated_contact'> `int fix_nated_contact()` </a> 
+
+#### KSR.nathelper.fix_nated_register() ####
+<a target='_blank' href='/docs/modules/devel/modules/nathelper.html#nathelper.f.fix_nated_register'> `int fix_nated_register()` </a> 
+
+#### KSR.nathelper.handle_ruri_alias() ####
+<a target='_blank' href='/docs/modules/devel/modules/nathelper.html#nathelper.f.handle_ruri_alias'> `int handle_ruri_alias()` </a> 
+
+#### KSR.nathelper.is_rfc1918() ####
+<a target='_blank' href='/docs/modules/devel/modules/nathelper.html#nathelper.f.is_rfc1918'> `int is_rfc1918(str "address")` </a> 
+
+#### KSR.nathelper.nat_uac_test() ####
+<a target='_blank' href='/docs/modules/devel/modules/nathelper.html#nathelper.f.nat_uac_test'> `int nat_uac_test(int tests)` </a> 
+
+#### KSR.nathelper.set_contact_alias() ####
+<a target='_blank' href='/docs/modules/devel/modules/nathelper.html#nathelper.f.set_contact_alias'> `int set_contact_alias()` </a> 
+
+## ndb_redis ##
+#### KSR.ndb_redis.redis_cmd() ####
+<a target='_blank' href='/docs/modules/devel/modules/ndb_redis.html#ndb_redis.f.redis_cmd'> `int redis_cmd(str "srv", str "rcmd", str "sres")` </a> 
+
+#### KSR.ndb_redis.redis_cmd_p1() ####
+<a target='_blank' href='/docs/modules/devel/modules/ndb_redis.html#ndb_redis.f.redis_cmd_p1'> `int redis_cmd_p1(str "srv", str "rcmd", str "p1", str "sres")` </a> 
+
+#### KSR.ndb_redis.redis_cmd_p2() ####
+<a target='_blank' href='/docs/modules/devel/modules/ndb_redis.html#ndb_redis.f.redis_cmd_p2'> `int redis_cmd_p2(str "srv", str "rcmd", str "p1", str "p2", str "sres")` </a> 
+
+#### KSR.ndb_redis.redis_cmd_p3() ####
+<a target='_blank' href='/docs/modules/devel/modules/ndb_redis.html#ndb_redis.f.redis_cmd_p3'> `int redis_cmd_p3(str "srv", str "rcmd", str "p1", str "p2", str "p3", str "sres")` </a> 
+
+#### KSR.ndb_redis.redis_free() ####
+<a target='_blank' href='/docs/modules/devel/modules/ndb_redis.html#ndb_redis.f.redis_free'> `int redis_free(str "name")` </a> 
+
+## path ##
+#### KSR.path.add_path() ####
+<a target='_blank' href='/docs/modules/devel/modules/path.html#path.f.add_path'> `int add_path()` </a> 
+
+#### KSR.path.add_path_received() ####
+<a target='_blank' href='/docs/modules/devel/modules/path.html#path.f.add_path_received'> `int add_path_received()` </a> 
+
+#### KSR.path.add_path_received_user() ####
+<a target='_blank' href='/docs/modules/devel/modules/path.html#path.f.add_path_received_user'> `int add_path_received_user(str "_user")` </a> 
+
+#### KSR.path.add_path_received_user_params() ####
+<a target='_blank' href='/docs/modules/devel/modules/path.html#path.f.add_path_received_user_params'> `int add_path_received_user_params(str "_user", str "_params")` </a> 
+
+#### KSR.path.add_path_user() ####
+<a target='_blank' href='/docs/modules/devel/modules/path.html#path.f.add_path_user'> `int add_path_user(str "_user")` </a> 
+
+#### KSR.path.add_path_user_params() ####
+<a target='_blank' href='/docs/modules/devel/modules/path.html#path.f.add_path_user_params'> `int add_path_user_params(str "_user", str "_params")` </a> 
+
+## pdt ##
+#### KSR.pdt.pd_translate() ####
+<a target='_blank' href='/docs/modules/devel/modules/pdt.html#pdt.f.pd_translate'> `int pd_translate(str "sd", int md)` </a> 
+
+#### KSR.pdt.pprefix2domain() ####
+<a target='_blank' href='/docs/modules/devel/modules/pdt.html#pdt.f.pprefix2domain'> `int pprefix2domain(int m, int s)` </a> 
+
+## permissions ##
+#### KSR.permissions.allow_address() ####
+<a target='_blank' href='/docs/modules/devel/modules/permissions.html#permissions.f.allow_address'> `int allow_address(int addr_group, str "ips", int port)` </a> 
+
+#### KSR.permissions.allow_source_address() ####
+<a target='_blank' href='/docs/modules/devel/modules/permissions.html#permissions.f.allow_source_address'> `int allow_source_address(int addr_group)` </a> 
+
+## phonenum ##
+#### KSR.phonenum.match() ####
+<a target='_blank' href='/docs/modules/devel/modules/phonenum.html#phonenum.f.match'> `int match(str "tomatch", str "pvclass")` </a> 
+
+## pike ##
+#### KSR.pike.pike_check_req() ####
+<a target='_blank' href='/docs/modules/devel/modules/pike.html#pike.f.pike_check_req'> `int pike_check_req()` </a> 
+
+## pipelimit ##
+#### KSR.pipelimit.pl_check() ####
+<a target='_blank' href='/docs/modules/devel/modules/pipelimit.html#pipelimit.f.pl_check'> `int pl_check(str "pipeid")` </a> 
+
+#### KSR.pipelimit.pl_check_limit() ####
+<a target='_blank' href='/docs/modules/devel/modules/pipelimit.html#pipelimit.f.pl_check_limit'> `int pl_check_limit(str "pipeid", str "alg", int limit)` </a> 
+
+#### KSR.pipelimit.pl_drop() ####
+<a target='_blank' href='/docs/modules/devel/modules/pipelimit.html#pipelimit.f.pl_drop'> `int pl_drop()` </a> 
+
+#### KSR.pipelimit.pl_drop_range() ####
+<a target='_blank' href='/docs/modules/devel/modules/pipelimit.html#pipelimit.f.pl_drop_range'> `int pl_drop_range(int rmin, int rmax)` </a> 
+
+#### KSR.pipelimit.pl_drop_retry() ####
+<a target='_blank' href='/docs/modules/devel/modules/pipelimit.html#pipelimit.f.pl_drop_retry'> `int pl_drop_retry(int rafter)` </a> 
+
+## prefix_route ##
+#### KSR.prefix_route.prefix_route() ####
+<a target='_blank' href='/docs/modules/devel/modules/prefix_route.html#prefix_route.f.prefix_route'> `int prefix_route(str "ruser")` </a> 
+
+#### KSR.prefix_route.prefix_route_uri() ####
+<a target='_blank' href='/docs/modules/devel/modules/prefix_route.html#prefix_route.f.prefix_route_uri'> `int prefix_route_uri()` </a> 
+
+## presence ##
+#### KSR.presence.handle_publish() ####
+<a target='_blank' href='/docs/modules/devel/modules/presence.html#presence.f.handle_publish'> `int handle_publish()` </a> 
+
+#### KSR.presence.handle_publish_uri() ####
+<a target='_blank' href='/docs/modules/devel/modules/presence.html#presence.f.handle_publish_uri'> `int handle_publish_uri(str "sender_uri")` </a> 
+
+#### KSR.presence.handle_subscribe() ####
+<a target='_blank' href='/docs/modules/devel/modules/presence.html#presence.f.handle_subscribe'> `int handle_subscribe()` </a> 
+
+#### KSR.presence.handle_subscribe_uri() ####
+<a target='_blank' href='/docs/modules/devel/modules/presence.html#presence.f.handle_subscribe_uri'> `int handle_subscribe_uri(str "wuri")` </a> 
+
+#### KSR.presence.pres_auth_status() ####
+<a target='_blank' href='/docs/modules/devel/modules/presence.html#presence.f.pres_auth_status'> `int pres_auth_status(str "watcher_uri", str "presentity_uri")` </a> 
+
+#### KSR.presence.pres_has_subscribers() ####
+<a target='_blank' href='/docs/modules/devel/modules/presence.html#presence.f.pres_has_subscribers'> `int pres_has_subscribers(str "pres_uri", str "wevent")` </a> 
+
+#### KSR.presence.pres_refresh_watchers() ####
+<a target='_blank' href='/docs/modules/devel/modules/presence.html#presence.f.pres_refresh_watchers'> `int pres_refresh_watchers(str "pres", str "event", int type)` </a> 
+
+#### KSR.presence.pres_refresh_watchers_file() ####
+<a target='_blank' href='/docs/modules/devel/modules/presence.html#presence.f.pres_refresh_watchers_file'> `int pres_refresh_watchers_file(str "pres", str "event", int type, str "file_uri", str "filename")` </a> 
+
+#### KSR.presence.pres_update_watchers() ####
+<a target='_blank' href='/docs/modules/devel/modules/presence.html#presence.f.pres_update_watchers'> `int pres_update_watchers(str "pres_uri", str "event")` </a> 
+
+## presence_xml ##
+#### KSR.presence_xml.pres_check_activities() ####
+<a target='_blank' href='/docs/modules/devel/modules/presence_xml.html#presence_xml.f.pres_check_activities'> `int pres_check_activities(str "pres_uri", str "activity")` </a> 
+
+#### KSR.presence_xml.pres_check_basic() ####
+<a target='_blank' href='/docs/modules/devel/modules/presence_xml.html#presence_xml.f.pres_check_basic'> `int pres_check_basic(str "pres_uri", str "status")` </a> 
+
+## pua ##
+#### KSR.pua.pua_set_publish() ####
+<a target='_blank' href='/docs/modules/devel/modules/pua.html#pua.f.pua_set_publish'> `int pua_set_publish()` </a> 
+
+#### KSR.pua.pua_update_contact() ####
+<a target='_blank' href='/docs/modules/devel/modules/pua.html#pua.f.pua_update_contact'> `int pua_update_contact()` </a> 
+
 ## pvx ##
 #### KSR.pvx.evalx() ####
-KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/pvx.html#pvx.f.evalx'> `int evalx(str, str)` </a> 
+<a target='_blank' href='/docs/modules/devel/modules/pvx.html#pvx.f.evalx'> `int evalx(str "dst", str "fmt")` </a> 
 
 #### KSR.pvx.pv_var_to_xavp() ####
-KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/pvx.html#pvx.f.pv_var_to_xavp'> `int pv_var_to_xavp(str, str)` </a> 
+<a target='_blank' href='/docs/modules/devel/modules/pvx.html#pvx.f.pv_var_to_xavp'> `int pv_var_to_xavp(str "varname", str "xname")` </a> 
 
 #### KSR.pvx.pv_xavp_print() ####
-KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/pvx.html#pvx.f.pv_xavp_print'> `int pv_xavp_print()` </a> 
+<a target='_blank' href='/docs/modules/devel/modules/pvx.html#pvx.f.pv_xavp_print'> `int pv_xavp_print()` </a> 
 
 #### KSR.pvx.pv_xavp_to_var() ####
-KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/pvx.html#pvx.f.pv_xavp_to_var'> `int pv_xavp_to_var(str)` </a> 
+<a target='_blank' href='/docs/modules/devel/modules/pvx.html#pvx.f.pv_xavp_to_var'> `int pv_xavp_to_var(str "xname")` </a> 
 
 #### KSR.pvx.sbranch_append() ####
-KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/pvx.html#pvx.f.sbranch_append'> `int sbranch_append()` </a> 
+<a target='_blank' href='/docs/modules/devel/modules/pvx.html#pvx.f.sbranch_append'> `int sbranch_append()` </a> 
 
 #### KSR.pvx.sbranch_reset() ####
-KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/pvx.html#pvx.f.sbranch_reset'> `int sbranch_reset()` </a> 
+<a target='_blank' href='/docs/modules/devel/modules/pvx.html#pvx.f.sbranch_reset'> `int sbranch_reset()` </a> 
 
 #### KSR.pvx.sbranch_set_ruri() ####
-KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/pvx.html#pvx.f.sbranch_set_ruri'> `int sbranch_set_ruri()` </a> 
+<a target='_blank' href='/docs/modules/devel/modules/pvx.html#pvx.f.sbranch_set_ruri'> `int sbranch_set_ruri()` </a> 
 
 #### KSR.pvx.xavp_params_explode() ####
-KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/pvx.html#pvx.f.xavp_params_explode'> `int xavp_params_explode(str, str)` </a> 
+<a target='_blank' href='/docs/modules/devel/modules/pvx.html#pvx.f.xavp_params_explode'> `int xavp_params_explode(str "sparams", str "sxname")` </a> 
+
+## regex ##
+#### KSR.regex.pcre_match() ####
+<a target='_blank' href='/docs/modules/devel/modules/regex.html#regex.f.pcre_match'> `int pcre_match(str "string", str "regex")` </a> 
+
+#### KSR.regex.pcre_match_group() ####
+<a target='_blank' href='/docs/modules/devel/modules/regex.html#regex.f.pcre_match_group'> `int pcre_match_group(str "string", int num_pcre)` </a> 
+
+## registrar ##
+#### KSR.registrar.add_sock_hdr() ####
+<a target='_blank' href='/docs/modules/devel/modules/registrar.html#registrar.f.add_sock_hdr'> `int add_sock_hdr(str "hdr_name")` </a> 
+
+#### KSR.registrar.lookup() ####
+<a target='_blank' href='/docs/modules/devel/modules/registrar.html#registrar.f.lookup'> `int lookup(str "table")` </a> 
+
+#### KSR.registrar.lookup_branches() ####
+<a target='_blank' href='/docs/modules/devel/modules/registrar.html#registrar.f.lookup_branches'> `int lookup_branches(str "_dtable")` </a> 
+
+#### KSR.registrar.lookup_to_dset() ####
+<a target='_blank' href='/docs/modules/devel/modules/registrar.html#registrar.f.lookup_to_dset'> `int lookup_to_dset(str "table", str "uri")` </a> 
+
+#### KSR.registrar.lookup_uri() ####
+<a target='_blank' href='/docs/modules/devel/modules/registrar.html#registrar.f.lookup_uri'> `int lookup_uri(str "table", str "")` </a> 
+
+#### KSR.registrar.reg_fetch_contacts() ####
+<a target='_blank' href='/docs/modules/devel/modules/registrar.html#registrar.f.reg_fetch_contacts'> `int reg_fetch_contacts(str "dtable", str "uri", str "profile")` </a> 
+
+#### KSR.registrar.reg_free_contacts() ####
+<a target='_blank' href='/docs/modules/devel/modules/registrar.html#registrar.f.reg_free_contacts'> `int reg_free_contacts(str "profile")` </a> 
+
+#### KSR.registrar.registered() ####
+<a target='_blank' href='/docs/modules/devel/modules/registrar.html#registrar.f.registered'> `int registered(str "table")` </a> 
+
+#### KSR.registrar.registered_action() ####
+<a target='_blank' href='/docs/modules/devel/modules/registrar.html#registrar.f.registered_action'> `int registered_action(str "_dtable", str "_uri", int _f, int _aflags)` </a> 
+
+#### KSR.registrar.registered_flags() ####
+<a target='_blank' href='/docs/modules/devel/modules/registrar.html#registrar.f.registered_flags'> `int registered_flags(str "_dtable", str "_uri", int _f)` </a> 
+
+#### KSR.registrar.registered_uri() ####
+<a target='_blank' href='/docs/modules/devel/modules/registrar.html#registrar.f.registered_uri'> `int registered_uri(str "_dtable", str "_uri")` </a> 
+
+#### KSR.registrar.save() ####
+<a target='_blank' href='/docs/modules/devel/modules/registrar.html#registrar.f.save'> `int save(str "table", int flags)` </a> 
+
+#### KSR.registrar.save_uri() ####
+<a target='_blank' href='/docs/modules/devel/modules/registrar.html#registrar.f.save_uri'> `int save_uri(str "table", int flags, str "uri")` </a> 
+
+#### KSR.registrar.set_q_override() ####
+<a target='_blank' href='/docs/modules/devel/modules/registrar.html#registrar.f.set_q_override'> `int set_q_override(str "new_q")` </a> 
+
+#### KSR.registrar.unregister() ####
+<a target='_blank' href='/docs/modules/devel/modules/registrar.html#registrar.f.unregister'> `int unregister(str "_dtable", str "_uri")` </a> 
+
+#### KSR.registrar.unregister_ruid() ####
+<a target='_blank' href='/docs/modules/devel/modules/registrar.html#registrar.f.unregister_ruid'> `int unregister_ruid(str "_dtable", str "_uri", str "_ruid")` </a> 
 
 ## rr ##
 #### KSR.rr.add_rr_param() ####
-KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/rr.html#rr.f.add_rr_param'> `int add_rr_param(str)` </a> 
+<a target='_blank' href='/docs/modules/devel/modules/rr.html#rr.f.add_rr_param'> `int add_rr_param(str "sparam")` </a> 
 
-Docs declaration: `int add_rr_param()`
 #### KSR.rr.check_route_param() ####
-KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/rr.html#rr.f.check_route_param'> `int check_route_param(str)` </a> 
+<a target='_blank' href='/docs/modules/devel/modules/rr.html#rr.f.check_route_param'> `int check_route_param(str "sre")` </a> 
 
-Docs declaration: `int check_route_param(re)`
 #### KSR.rr.loose_route() ####
-KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/rr.html#rr.f.loose_route'> `int loose_route()` </a> 
+<a target='_blank' href='/docs/modules/devel/modules/rr.html#rr.f.loose_route'> `int loose_route()` </a> 
 
 #### KSR.rr.record_route() ####
-KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/rr.html#rr.f.record_route'> `int record_route()` </a> 
+<a target='_blank' href='/docs/modules/devel/modules/rr.html#rr.f.record_route'> `int record_route()` </a> 
 
 #### KSR.rr.record_route_params() ####
-KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/rr.html#rr.f.record_route_params'> `int record_route_params(str)` </a> 
+<a target='_blank' href='/docs/modules/devel/modules/rr.html#rr.f.record_route_params'> `int record_route_params(str "params")` </a> 
 
 #### KSR.rr.remove_record_route() ####
-KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/rr.html#rr.f.remove_record_route'> `int remove_record_route()` </a> 
+<a target='_blank' href='/docs/modules/devel/modules/rr.html#rr.f.remove_record_route'> `int remove_record_route()` </a> 
+
+## rtjson ##
+#### KSR.rtjson.init_routes() ####
+<a target='_blank' href='/docs/modules/devel/modules/rtjson.html#rtjson.f.init_routes'> `int init_routes(str "rdoc")` </a> 
+
+#### KSR.rtjson.next_route() ####
+<a target='_blank' href='/docs/modules/devel/modules/rtjson.html#rtjson.f.next_route'> `int next_route()` </a> 
+
+#### KSR.rtjson.push_routes() ####
+<a target='_blank' href='/docs/modules/devel/modules/rtjson.html#rtjson.f.push_routes'> `int push_routes()` </a> 
+
+#### KSR.rtjson.update_branch() ####
+<a target='_blank' href='/docs/modules/devel/modules/rtjson.html#rtjson.f.update_branch'> `int update_branch()` </a> 
+
+## rtpengine ##
+#### KSR.rtpengine.rtpengine_answer() ####
+<a target='_blank' href='/docs/modules/devel/modules/rtpengine.html#rtpengine.f.rtpengine_answer'> `int rtpengine_answer(str "flags")` </a> 
+
+#### KSR.rtpengine.rtpengine_answer0() ####
+<a target='_blank' href='/docs/modules/devel/modules/rtpengine.html#rtpengine.f.rtpengine_answer0'> `int rtpengine_answer0()` </a> 
+
+#### KSR.rtpengine.rtpengine_delete() ####
+<a target='_blank' href='/docs/modules/devel/modules/rtpengine.html#rtpengine.f.rtpengine_delete'> `int rtpengine_delete(str "flags")` </a> 
+
+#### KSR.rtpengine.rtpengine_delete0() ####
+<a target='_blank' href='/docs/modules/devel/modules/rtpengine.html#rtpengine.f.rtpengine_delete0'> `int rtpengine_delete0()` </a> 
+
+#### KSR.rtpengine.rtpengine_manage() ####
+<a target='_blank' href='/docs/modules/devel/modules/rtpengine.html#rtpengine.f.rtpengine_manage'> `int rtpengine_manage(str "flags")` </a> 
+
+#### KSR.rtpengine.rtpengine_manage0() ####
+<a target='_blank' href='/docs/modules/devel/modules/rtpengine.html#rtpengine.f.rtpengine_manage0'> `int rtpengine_manage0()` </a> 
+
+#### KSR.rtpengine.rtpengine_offer() ####
+<a target='_blank' href='/docs/modules/devel/modules/rtpengine.html#rtpengine.f.rtpengine_offer'> `int rtpengine_offer(str "flags")` </a> 
+
+#### KSR.rtpengine.rtpengine_offer0() ####
+<a target='_blank' href='/docs/modules/devel/modules/rtpengine.html#rtpengine.f.rtpengine_offer0'> `int rtpengine_offer0()` </a> 
+
+#### KSR.rtpengine.set_rtpengine_set() ####
+<a target='_blank' href='/docs/modules/devel/modules/rtpengine.html#rtpengine.f.set_rtpengine_set'> `int set_rtpengine_set(int r1)` </a> 
+
+#### KSR.rtpengine.set_rtpengine_set2() ####
+<a target='_blank' href='/docs/modules/devel/modules/rtpengine.html#rtpengine.f.set_rtpengine_set2'> `int set_rtpengine_set2(int r1, int r2)` </a> 
+
+#### KSR.rtpengine.start_recording() ####
+<a target='_blank' href='/docs/modules/devel/modules/rtpengine.html#rtpengine.f.start_recording'> `int start_recording()` </a> 
+
+#### KSR.rtpengine.stop_recording() ####
+<a target='_blank' href='/docs/modules/devel/modules/rtpengine.html#rtpengine.f.stop_recording'> `int stop_recording()` </a> 
+
+## rtpproxy ##
+#### KSR.rtpproxy.rtpproxy_answer() ####
+<a target='_blank' href='/docs/modules/devel/modules/rtpproxy.html#rtpproxy.f.rtpproxy_answer'> `int rtpproxy_answer(str "flags")` </a> 
+
+#### KSR.rtpproxy.rtpproxy_answer0() ####
+<a target='_blank' href='/docs/modules/devel/modules/rtpproxy.html#rtpproxy.f.rtpproxy_answer0'> `int rtpproxy_answer0()` </a> 
+
+#### KSR.rtpproxy.rtpproxy_answer_ip() ####
+<a target='_blank' href='/docs/modules/devel/modules/rtpproxy.html#rtpproxy.f.rtpproxy_answer_ip'> `int rtpproxy_answer_ip(str "flags", str "mip")` </a> 
+
+#### KSR.rtpproxy.rtpproxy_destroy() ####
+<a target='_blank' href='/docs/modules/devel/modules/rtpproxy.html#rtpproxy.f.rtpproxy_destroy'> `int rtpproxy_destroy(str "flags")` </a> 
+
+#### KSR.rtpproxy.rtpproxy_destroy0() ####
+<a target='_blank' href='/docs/modules/devel/modules/rtpproxy.html#rtpproxy.f.rtpproxy_destroy0'> `int rtpproxy_destroy0()` </a> 
+
+#### KSR.rtpproxy.rtpproxy_manage() ####
+<a target='_blank' href='/docs/modules/devel/modules/rtpproxy.html#rtpproxy.f.rtpproxy_manage'> `int rtpproxy_manage(str "flags")` </a> 
+
+#### KSR.rtpproxy.rtpproxy_manage0() ####
+<a target='_blank' href='/docs/modules/devel/modules/rtpproxy.html#rtpproxy.f.rtpproxy_manage0'> `int rtpproxy_manage0()` </a> 
+
+#### KSR.rtpproxy.rtpproxy_manage_ip() ####
+<a target='_blank' href='/docs/modules/devel/modules/rtpproxy.html#rtpproxy.f.rtpproxy_manage_ip'> `int rtpproxy_manage_ip(str "flags", str "mip")` </a> 
+
+#### KSR.rtpproxy.rtpproxy_offer() ####
+<a target='_blank' href='/docs/modules/devel/modules/rtpproxy.html#rtpproxy.f.rtpproxy_offer'> `int rtpproxy_offer(str "flags")` </a> 
+
+#### KSR.rtpproxy.rtpproxy_offer0() ####
+<a target='_blank' href='/docs/modules/devel/modules/rtpproxy.html#rtpproxy.f.rtpproxy_offer0'> `int rtpproxy_offer0()` </a> 
+
+#### KSR.rtpproxy.rtpproxy_offer_ip() ####
+<a target='_blank' href='/docs/modules/devel/modules/rtpproxy.html#rtpproxy.f.rtpproxy_offer_ip'> `int rtpproxy_offer_ip(str "flags", str "mip")` </a> 
+
+#### KSR.rtpproxy.rtpproxy_stop_stream2uac() ####
+<a target='_blank' href='/docs/modules/devel/modules/rtpproxy.html#rtpproxy.f.rtpproxy_stop_stream2uac'> `int rtpproxy_stop_stream2uac()` </a> 
+
+#### KSR.rtpproxy.rtpproxy_stop_stream2uas() ####
+<a target='_blank' href='/docs/modules/devel/modules/rtpproxy.html#rtpproxy.f.rtpproxy_stop_stream2uas'> `int rtpproxy_stop_stream2uas()` </a> 
+
+#### KSR.rtpproxy.rtpproxy_stream2uac() ####
+<a target='_blank' href='/docs/modules/devel/modules/rtpproxy.html#rtpproxy.f.rtpproxy_stream2uac'> `int rtpproxy_stream2uac(str "pname", int count)` </a> 
+
+#### KSR.rtpproxy.rtpproxy_stream2uas() ####
+<a target='_blank' href='/docs/modules/devel/modules/rtpproxy.html#rtpproxy.f.rtpproxy_stream2uas'> `int rtpproxy_stream2uas(str "pname", int count)` </a> 
+
+#### KSR.rtpproxy.set_rtpproxy_set() ####
+<a target='_blank' href='/docs/modules/devel/modules/rtpproxy.html#rtpproxy.f.set_rtpproxy_set'> `int set_rtpproxy_set(int rset)` </a> 
+
+#### KSR.rtpproxy.start_recording() ####
+<a target='_blank' href='/docs/modules/devel/modules/rtpproxy.html#rtpproxy.f.start_recording'> `int start_recording()` </a> 
 
 ## sanity ##
 #### KSR.sanity.sanity_check() ####
-KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/sanity.html#sanity.f.sanity_check'> `int sanity_check(int, int)` </a> 
+<a target='_blank' href='/docs/modules/devel/modules/sanity.html#sanity.f.sanity_check'> `int sanity_check(int mflags, int uflags)` </a> 
 
-Docs declaration: `int sanity_check([msg_checks [, uri_checks]])`
 #### KSR.sanity.sanity_check_defaults() ####
-KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/sanity.html#sanity.f.sanity_check_defaults'> `int sanity_check_defaults()` </a> 
+<a target='_blank' href='/docs/modules/devel/modules/sanity.html#sanity.f.sanity_check_defaults'> `int sanity_check_defaults()` </a> 
+
+## sdpops ##
+#### KSR.sdpops.keep_codecs_by_id() ####
+<a target='_blank' href='/docs/modules/devel/modules/sdpops.html#sdpops.f.keep_codecs_by_id'> `int keep_codecs_by_id(str "codecs", str "media")` </a> 
+
+#### KSR.sdpops.keep_codecs_by_name() ####
+<a target='_blank' href='/docs/modules/devel/modules/sdpops.html#sdpops.f.keep_codecs_by_name'> `int keep_codecs_by_name(str "codecs", str "media")` </a> 
+
+#### KSR.sdpops.remove_codecs_by_id() ####
+<a target='_blank' href='/docs/modules/devel/modules/sdpops.html#sdpops.f.remove_codecs_by_id'> `int remove_codecs_by_id(str "codecs", str "media")` </a> 
+
+#### KSR.sdpops.remove_codecs_by_name() ####
+<a target='_blank' href='/docs/modules/devel/modules/sdpops.html#sdpops.f.remove_codecs_by_name'> `int remove_codecs_by_name(str "codecs", str "media")` </a> 
+
+#### KSR.sdpops.remove_line_by_prefix() ####
+<a target='_blank' href='/docs/modules/devel/modules/sdpops.html#sdpops.f.remove_line_by_prefix'> `int remove_line_by_prefix(str "prefix", str "media")` </a> 
+
+#### KSR.sdpops.remove_media() ####
+<a target='_blank' href='/docs/modules/devel/modules/sdpops.html#sdpops.f.remove_media'> `int remove_media(str "media")` </a> 
+
+#### KSR.sdpops.sdp_content() ####
+<a target='_blank' href='/docs/modules/devel/modules/sdpops.html#sdpops.f.sdp_content'> `int sdp_content()` </a> 
+
+#### KSR.sdpops.sdp_content_flags() ####
+<a target='_blank' href='/docs/modules/devel/modules/sdpops.html#sdpops.f.sdp_content_flags'> `int sdp_content_flags(int flags)` </a> 
+
+#### KSR.sdpops.sdp_get() ####
+<a target='_blank' href='/docs/modules/devel/modules/sdpops.html#sdpops.f.sdp_get'> `int sdp_get(str "avp")` </a> 
+
+#### KSR.sdpops.sdp_transport() ####
+<a target='_blank' href='/docs/modules/devel/modules/sdpops.html#sdpops.f.sdp_transport'> `int sdp_transport(str "avp")` </a> 
+
+#### KSR.sdpops.sdp_with_ice() ####
+<a target='_blank' href='/docs/modules/devel/modules/sdpops.html#sdpops.f.sdp_with_ice'> `int sdp_with_ice()` </a> 
+
+## sipcapture ##
+#### KSR.sipcapture.float2int() ####
+<a target='_blank' href='/docs/modules/devel/modules/sipcapture.html#sipcapture.f.float2int'> `int float2int(str "_val", str "_coof")` </a> 
+
+#### KSR.sipcapture.report_capture() ####
+<a target='_blank' href='/docs/modules/devel/modules/sipcapture.html#sipcapture.f.report_capture'> `int report_capture(str "_table")` </a> 
+
+#### KSR.sipcapture.report_capture_cid() ####
+<a target='_blank' href='/docs/modules/devel/modules/sipcapture.html#sipcapture.f.report_capture_cid'> `int report_capture_cid(str "_table", str "_cid")` </a> 
+
+#### KSR.sipcapture.report_capture_data() ####
+<a target='_blank' href='/docs/modules/devel/modules/sipcapture.html#sipcapture.f.report_capture_data'> `int report_capture_data(str "_table", str "_cid", str "_data")` </a> 
+
+#### KSR.sipcapture.sip_capture() ####
+<a target='_blank' href='/docs/modules/devel/modules/sipcapture.html#sipcapture.f.sip_capture'> `int sip_capture()` </a> 
+
+#### KSR.sipcapture.sip_capture_mode() ####
+<a target='_blank' href='/docs/modules/devel/modules/sipcapture.html#sipcapture.f.sip_capture_mode'> `int sip_capture_mode(str "_table", str "_cmdata")` </a> 
+
+#### KSR.sipcapture.sip_capture_table() ####
+<a target='_blank' href='/docs/modules/devel/modules/sipcapture.html#sipcapture.f.sip_capture_table'> `int sip_capture_table(str "_table")` </a> 
+
+## sipdump ##
+#### KSR.sipdump.send() ####
+<a target='_blank' href='/docs/modules/devel/modules/sipdump.html#sipdump.f.send'> `int send(str "stag")` </a> 
+
+## siptrace ##
+#### KSR.siptrace.hlog() ####
+<a target='_blank' href='/docs/modules/devel/modules/siptrace.html#siptrace.f.hlog'> `int hlog(str "message")` </a> 
+
+#### KSR.siptrace.hlog_cid() ####
+<a target='_blank' href='/docs/modules/devel/modules/siptrace.html#siptrace.f.hlog_cid'> `int hlog_cid(str "correlationid", str "message")` </a> 
+
+#### KSR.siptrace.sip_trace() ####
+<a target='_blank' href='/docs/modules/devel/modules/siptrace.html#siptrace.f.sip_trace'> `int sip_trace()` </a> 
+
+#### KSR.siptrace.sip_trace_dst() ####
+<a target='_blank' href='/docs/modules/devel/modules/siptrace.html#siptrace.f.sip_trace_dst'> `int sip_trace_dst(str "duri")` </a> 
+
+#### KSR.siptrace.sip_trace_dst_cid() ####
+<a target='_blank' href='/docs/modules/devel/modules/siptrace.html#siptrace.f.sip_trace_dst_cid'> `int sip_trace_dst_cid(str "duri", str "cid")` </a> 
 
 ## siputils ##
 #### KSR.siputils.has_totag() ####
-KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/siputils.html#siputils.f.has_totag'> `int has_totag()` </a> 
+<a target='_blank' href='/docs/modules/devel/modules/siputils.html#siputils.f.has_totag'> `int has_totag()` </a> 
 
 #### KSR.siputils.is_first_hop() ####
-KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/siputils.html#siputils.f.is_first_hop'> `int is_first_hop()` </a> 
+<a target='_blank' href='/docs/modules/devel/modules/siputils.html#siputils.f.is_first_hop'> `int is_first_hop()` </a> 
 
 #### KSR.siputils.is_reply() ####
-KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/siputils.html#siputils.f.is_reply'> `int is_reply()` </a> 
+<a target='_blank' href='/docs/modules/devel/modules/siputils.html#siputils.f.is_reply'> `int is_reply()` </a> 
 
 #### KSR.siputils.is_request() ####
-KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/siputils.html#siputils.f.is_request'> `int is_request()` </a> 
+<a target='_blank' href='/docs/modules/devel/modules/siputils.html#siputils.f.is_request'> `int is_request()` </a> 
 
 ## sl ##
 #### KSR.sl.send_reply() ####
-KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/sl.html#sl.f.send_reply'> `int send_reply(int, str)` </a> 
+<a target='_blank' href='/docs/modules/devel/modules/sl.html#sl.f.send_reply'> `int send_reply(int code, str "reason")` </a> 
 
-Docs declaration: `int send_reply(code, reason)`
 #### KSR.sl.sl_forward_reply() ####
-KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/sl.html#sl.f.sl_forward_reply'> `int sl_forward_reply(str, str)` </a> 
+<a target='_blank' href='/docs/modules/devel/modules/sl.html#sl.f.sl_forward_reply'> `int sl_forward_reply(str "code", str "reason")` </a> 
 
-Docs declaration: `int sl_forward_reply("404", "Not found")`
 #### KSR.sl.sl_reply_error() ####
-KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/sl.html#sl.f.sl_reply_error'> `int sl_reply_error()` </a> 
+<a target='_blank' href='/docs/modules/devel/modules/sl.html#sl.f.sl_reply_error'> `int sl_reply_error()` </a> 
 
 #### KSR.sl.sl_send_reply() ####
-KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/sl.html#sl.f.sl_send_reply'> `int sl_send_reply(int, str)` </a> 
+<a target='_blank' href='/docs/modules/devel/modules/sl.html#sl.f.sl_send_reply'> `int sl_send_reply(int code, str "reason")` </a> 
 
-Docs declaration: `int sl_send_reply(code, reason)`
+## speeddial ##
+#### KSR.speeddial.lookup() ####
+<a target='_blank' href='/docs/modules/devel/modules/speeddial.html#speeddial.f.lookup'> `int lookup(str "stable")` </a> 
+
+#### KSR.speeddial.lookup_owner() ####
+<a target='_blank' href='/docs/modules/devel/modules/speeddial.html#speeddial.f.lookup_owner'> `int lookup_owner(str "stable", str "sowner")` </a> 
+
+## sqlops ##
+#### KSR.sqlops.sql_is_null() ####
+<a target='_blank' href='/docs/modules/devel/modules/sqlops.html#sqlops.f.sql_is_null'> `int sql_is_null(str "sres", int i, int j)` </a> 
+
+#### KSR.sqlops.sql_num_columns() ####
+<a target='_blank' href='/docs/modules/devel/modules/sqlops.html#sqlops.f.sql_num_columns'> `int sql_num_columns(str "sres")` </a> 
+
+#### KSR.sqlops.sql_num_rows() ####
+<a target='_blank' href='/docs/modules/devel/modules/sqlops.html#sqlops.f.sql_num_rows'> `int sql_num_rows(str "sres")` </a> 
+
+#### KSR.sqlops.sql_query() ####
+<a target='_blank' href='/docs/modules/devel/modules/sqlops.html#sqlops.f.sql_query'> `int sql_query(str "scon", str "squery", str "sres")` </a> 
+
+#### KSR.sqlops.sql_result_free() ####
+<a target='_blank' href='/docs/modules/devel/modules/sqlops.html#sqlops.f.sql_result_free'> `int sql_result_free(str "sres")` </a> 
+
+#### KSR.sqlops.sql_xquery() ####
+<a target='_blank' href='/docs/modules/devel/modules/sqlops.html#sqlops.f.sql_xquery'> `int sql_xquery(str "scon", str "squery", str "xavp")` </a> 
+
+## ss7ops ##
+#### KSR.ss7ops.isup_to_json() ####
+<a target='_blank' href='/docs/modules/devel/modules/ss7ops.html#ss7ops.f.isup_to_json'> `int isup_to_json(int proto)` </a> 
+
+## sst ##
+#### KSR.sst.sst_check_min() ####
+<a target='_blank' href='/docs/modules/devel/modules/sst.html#sst.f.sst_check_min'> `int sst_check_min(int flag)` </a> 
+
+## statistics ##
+#### KSR.statistics.reset_stat() ####
+<a target='_blank' href='/docs/modules/devel/modules/statistics.html#statistics.f.reset_stat'> `int reset_stat(str "sname")` </a> 
+
+#### KSR.statistics.update_stat() ####
+<a target='_blank' href='/docs/modules/devel/modules/statistics.html#statistics.f.update_stat'> `int update_stat(str "sname", int sval)` </a> 
+
+## statsc ##
+#### KSR.statsc.statsc_reset() ####
+<a target='_blank' href='/docs/modules/devel/modules/statsc.html#statsc.f.statsc_reset'> `int statsc_reset()` </a> 
+
+## statsd ##
+#### KSR.statsd.statsd_decr() ####
+<a target='_blank' href='/docs/modules/devel/modules/statsd.html#statsd.f.statsd_decr'> `int statsd_decr(str "key")` </a> 
+
+#### KSR.statsd.statsd_gauge() ####
+<a target='_blank' href='/docs/modules/devel/modules/statsd.html#statsd.f.statsd_gauge'> `int statsd_gauge(str "key", str "val")` </a> 
+
+#### KSR.statsd.statsd_incr() ####
+<a target='_blank' href='/docs/modules/devel/modules/statsd.html#statsd.f.statsd_incr'> `int statsd_incr(str "key")` </a> 
+
+#### KSR.statsd.statsd_set() ####
+<a target='_blank' href='/docs/modules/devel/modules/statsd.html#statsd.f.statsd_set'> `int statsd_set(str "key", str "val")` </a> 
+
+#### KSR.statsd.statsd_start() ####
+<a target='_blank' href='/docs/modules/devel/modules/statsd.html#statsd.f.statsd_start'> `int statsd_start(str "key")` </a> 
+
+#### KSR.statsd.statsd_stop() ####
+<a target='_blank' href='/docs/modules/devel/modules/statsd.html#statsd.f.statsd_stop'> `int statsd_stop(str "key")` </a> 
+
 ## textops ##
 #### KSR.textops.cmp_istr() ####
-KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/textops.html#textops.f.cmp_istr'> `int cmp_istr(str, str)` </a> 
+<a target='_blank' href='/docs/modules/devel/modules/textops.html#textops.f.cmp_istr'> `int cmp_istr(str "s1", str "s2")` </a> 
 
-Docs declaration: `int cmp_istr(str1, str2)`
 #### KSR.textops.cmp_str() ####
-KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/textops.html#textops.f.cmp_str'> `int cmp_str(str, str)` </a> 
+<a target='_blank' href='/docs/modules/devel/modules/textops.html#textops.f.cmp_str'> `int cmp_str(str "s1", str "s2")` </a> 
 
-Docs declaration: `int cmp_str(str1, str2)`
 #### KSR.textops.filter_body() ####
-KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/textops.html#textops.f.filter_body'> `int filter_body(str)` </a> 
+<a target='_blank' href='/docs/modules/devel/modules/textops.html#textops.f.filter_body'> `int filter_body(str "content_type")` </a> 
 
-Docs declaration: `int filter_body(content_type)`
 #### KSR.textops.has_body() ####
-KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/textops.html#textops.f.has_body'> `int has_body()` </a> 
+<a target='_blank' href='/docs/modules/devel/modules/textops.html#textops.f.has_body'> `int has_body()` </a> 
 
 #### KSR.textops.has_body_type() ####
-KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/textops.html#textops.f.has_body_type'> `int has_body_type(str)` </a> 
+<a target='_blank' href='/docs/modules/devel/modules/textops.html#textops.f.has_body_type'> `int has_body_type(str "ctype")` </a> 
 
 #### KSR.textops.is_audio_on_hold() ####
-KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/textops.html#textops.f.is_audio_on_hold'> `int is_audio_on_hold()` </a> 
+<a target='_blank' href='/docs/modules/devel/modules/textops.html#textops.f.is_audio_on_hold'> `int is_audio_on_hold()` </a> 
 
 #### KSR.textops.is_list() ####
-KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/textops.html#textops.f.is_list'> `int is_list(str, str, str)` </a> 
+<a target='_blank' href='/docs/modules/devel/modules/textops.html#textops.f.is_list'> `int is_list(str "subject", str "list", str "vsep")` </a> 
 
 #### KSR.textops.is_present_hf() ####
-KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/textops.html#textops.f.is_present_hf'> `int is_present_hf(str)` </a> 
+<a target='_blank' href='/docs/modules/devel/modules/textops.html#textops.f.is_present_hf'> `int is_present_hf(str "hname")` </a> 
 
-Docs declaration: `int is_present_hf(hf_name)`
 #### KSR.textops.is_present_hf_re() ####
-KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/textops.html#textops.f.is_present_hf_re'> `int is_present_hf_re(str)` </a> 
+<a target='_blank' href='/docs/modules/devel/modules/textops.html#textops.f.is_present_hf_re'> `int is_present_hf_re(str "ematch")` </a> 
 
-Docs declaration: `int is_present_hf_re(hf_name_re)`
 #### KSR.textops.is_privacy() ####
-KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/textops.html#textops.f.is_privacy'> `int is_privacy(str)` </a> 
+<a target='_blank' href='/docs/modules/devel/modules/textops.html#textops.f.is_privacy'> `int is_privacy(str "privacy")` </a> 
 
-Docs declaration: `int is_privacy(privacy_type)`
 #### KSR.textops.remove_hf_exp() ####
-KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/textops.html#textops.f.remove_hf_exp'> `int remove_hf_exp(str, str)` </a> 
+<a target='_blank' href='/docs/modules/devel/modules/textops.html#textops.f.remove_hf_exp'> `int remove_hf_exp(str "ematch", str "eskip")` </a> 
 
-Docs declaration: `int remove_hf_exp(expmatch, expskip)`
 #### KSR.textops.remove_hf_re() ####
-KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/textops.html#textops.f.remove_hf_re'> `int remove_hf_re(str)` </a> 
+<a target='_blank' href='/docs/modules/devel/modules/textops.html#textops.f.remove_hf_re'> `int remove_hf_re(str "ematch")` </a> 
 
-Docs declaration: `int remove_hf_re(re)`
 #### KSR.textops.replace() ####
-KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/textops.html#textops.f.replace'> `int replace(str, str)` </a> 
+<a target='_blank' href='/docs/modules/devel/modules/textops.html#textops.f.replace'> `int replace(str "sre", str "sval")` </a> 
 
-Docs declaration: `int replace(re, txt)`
 #### KSR.textops.replace_all() ####
-KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/textops.html#textops.f.replace_all'> `int replace_all(str, str)` </a> 
+<a target='_blank' href='/docs/modules/devel/modules/textops.html#textops.f.replace_all'> `int replace_all(str "sre", str "sval")` </a> 
 
-Docs declaration: `int replace_all(re, txt)`
 #### KSR.textops.replace_body() ####
-KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/textops.html#textops.f.replace_body'> `int replace_body(str, str)` </a> 
+<a target='_blank' href='/docs/modules/devel/modules/textops.html#textops.f.replace_body'> `int replace_body(str "sre", str "sval")` </a> 
 
-Docs declaration: `int replace_body(re, txt)`
 #### KSR.textops.replace_body_all() ####
-KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/textops.html#textops.f.replace_body_all'> `int replace_body_all(str, str)` </a> 
+<a target='_blank' href='/docs/modules/devel/modules/textops.html#textops.f.replace_body_all'> `int replace_body_all(str "sre", str "sval")` </a> 
 
-Docs declaration: `int replace_body_all(re, txt)`
 #### KSR.textops.replace_body_atonce() ####
-KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/textops.html#textops.f.replace_body_atonce'> `int replace_body_atonce(str, str)` </a> 
+<a target='_blank' href='/docs/modules/devel/modules/textops.html#textops.f.replace_body_atonce'> `int replace_body_atonce(str "sre", str "sval")` </a> 
 
-Docs declaration: `int replace_body_atonce(re, txt)`
 #### KSR.textops.search() ####
-KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/textops.html#textops.f.search'> `int search(str)` </a> 
+<a target='_blank' href='/docs/modules/devel/modules/textops.html#textops.f.search'> `int search(str "sre")` </a> 
 
-Docs declaration: `int search(re)`
 #### KSR.textops.search_append() ####
-KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/textops.html#textops.f.search_append'> `int search_append(str)` </a> 
+<a target='_blank' href='/docs/modules/devel/modules/textops.html#textops.f.search_append'> `int search_append(str "ematch", str "val")` </a> 
 
-Docs declaration: `int search_append(re, txt)`
 #### KSR.textops.search_append_body() ####
-KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/textops.html#textops.f.search_append_body'> `int search_append_body(str)` </a> 
+<a target='_blank' href='/docs/modules/devel/modules/textops.html#textops.f.search_append_body'> `int search_append_body(str "ematch", str "val")` </a> 
 
-Docs declaration: `int search_append_body(re, txt)`
 #### KSR.textops.search_body() ####
-KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/textops.html#textops.f.search_body'> `int search_body(str)` </a> 
+<a target='_blank' href='/docs/modules/devel/modules/textops.html#textops.f.search_body'> `int search_body(str "sre")` </a> 
 
-Docs declaration: `int search_body(re)`
 #### KSR.textops.search_hf() ####
-KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/textops.html#textops.f.search_hf'> `int search_hf(str, str, str)` </a> 
+<a target='_blank' href='/docs/modules/devel/modules/textops.html#textops.f.search_hf'> `int search_hf(str "hname", str "sre", str "flags")` </a> 
 
-Docs declaration: `int search_hf(hf, re, flags)`
 #### KSR.textops.set_body() ####
-KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/textops.html#textops.f.set_body'> `int set_body(str, str)` </a> 
+<a target='_blank' href='/docs/modules/devel/modules/textops.html#textops.f.set_body'> `int set_body(str "nb", str "nc")` </a> 
 
-Docs declaration: `int set_body(txt,content_type)`
 #### KSR.textops.set_reply_body() ####
-KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/textops.html#textops.f.set_reply_body'> `int set_reply_body(str, str)` </a> 
+<a target='_blank' href='/docs/modules/devel/modules/textops.html#textops.f.set_reply_body'> `int set_reply_body(str "nb", str "nc")` </a> 
 
-Docs declaration: `int set_reply_body(txt,content_type)`
 #### KSR.textops.starts_with() ####
-KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/textops.html#textops.f.starts_with'> `int starts_with(str, str)` </a> 
+<a target='_blank' href='/docs/modules/devel/modules/textops.html#textops.f.starts_with'> `int starts_with(str "s1", str "s2")` </a> 
 
-Docs declaration: `int starts_with(str1, str2)`
 #### KSR.textops.subst() ####
-KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/textops.html#textops.f.subst'> `int subst(str)` </a> 
+<a target='_blank' href='/docs/modules/devel/modules/textops.html#textops.f.subst'> `int subst(str "subst")` </a> 
 
-Docs declaration: `int subst('/re/repl/flags')`
 #### KSR.textops.subst_body() ####
-KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/textops.html#textops.f.subst_body'> `int subst_body(str)` </a> 
+<a target='_blank' href='/docs/modules/devel/modules/textops.html#textops.f.subst_body'> `int subst_body(str "subst")` </a> 
 
-Docs declaration: `int subst_body('/re/repl/flags')`
 #### KSR.textops.subst_hf() ####
-KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/textops.html#textops.f.subst_hf'> `int subst_hf(str, str, str)` </a> 
+<a target='_blank' href='/docs/modules/devel/modules/textops.html#textops.f.subst_hf'> `int subst_hf(str "hname", str "subst", str "flags")` </a> 
 
-Docs declaration: `int subst_hf(hf, subexp, flags)`
 #### KSR.textops.subst_uri() ####
-KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/textops.html#textops.f.subst_uri'> `int subst_uri(str)` </a> 
+<a target='_blank' href='/docs/modules/devel/modules/textops.html#textops.f.subst_uri'> `int subst_uri(str "subst")` </a> 
 
-Docs declaration: `int subst_uri('/re/repl/flags')`
 #### KSR.textops.subst_user() ####
-KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/textops.html#textops.f.subst_user'> `int subst_user(str)` </a> 
+<a target='_blank' href='/docs/modules/devel/modules/textops.html#textops.f.subst_user'> `int subst_user(str "subst")` </a> 
 
-Docs declaration: `int subst_user('/re/repl/flags')`
+## textopsx ##
+#### KSR.textopsx.append_hf_value() ####
+<a target='_blank' href='/docs/modules/devel/modules/textopsx.html#textopsx.f.append_hf_value'> `int append_hf_value(str "hexp", str "val")` </a> 
+
+#### KSR.textopsx.assign_hf_value() ####
+<a target='_blank' href='/docs/modules/devel/modules/textopsx.html#textopsx.f.assign_hf_value'> `int assign_hf_value(str "hexp", str "val")` </a> 
+
+#### KSR.textopsx.assign_hf_value2() ####
+<a target='_blank' href='/docs/modules/devel/modules/textopsx.html#textopsx.f.assign_hf_value2'> `int assign_hf_value2(str "hexp", str "val")` </a> 
+
+#### KSR.textopsx.change_reply_status() ####
+<a target='_blank' href='/docs/modules/devel/modules/textopsx.html#textopsx.f.change_reply_status'> `int change_reply_status(int code, str "reason")` </a> 
+
+#### KSR.textopsx.exclude_hf_value() ####
+<a target='_blank' href='/docs/modules/devel/modules/textopsx.html#textopsx.f.exclude_hf_value'> `int exclude_hf_value(str "hexp", str "val")` </a> 
+
+#### KSR.textopsx.fnmatch() ####
+<a target='_blank' href='/docs/modules/devel/modules/textopsx.html#textopsx.f.fnmatch'> `int fnmatch(str "val", str "match")` </a> 
+
+#### KSR.textopsx.fnmatch_ex() ####
+<a target='_blank' href='/docs/modules/devel/modules/textopsx.html#textopsx.f.fnmatch_ex'> `int fnmatch_ex(str "val", str "match", str "flags")` </a> 
+
+#### KSR.textopsx.hf_value_exists() ####
+<a target='_blank' href='/docs/modules/devel/modules/textopsx.html#textopsx.f.hf_value_exists'> `int hf_value_exists(str "hexp", str "val")` </a> 
+
+#### KSR.textopsx.include_hf_value() ####
+<a target='_blank' href='/docs/modules/devel/modules/textopsx.html#textopsx.f.include_hf_value'> `int include_hf_value(str "hexp", str "val")` </a> 
+
+#### KSR.textopsx.insert_hf_value() ####
+<a target='_blank' href='/docs/modules/devel/modules/textopsx.html#textopsx.f.insert_hf_value'> `int insert_hf_value(str "hexp", str "val")` </a> 
+
+#### KSR.textopsx.keep_hf() ####
+<a target='_blank' href='/docs/modules/devel/modules/textopsx.html#textopsx.f.keep_hf'> `int keep_hf()` </a> 
+
+#### KSR.textopsx.keep_hf_re() ####
+<a target='_blank' href='/docs/modules/devel/modules/textopsx.html#textopsx.f.keep_hf_re'> `int keep_hf_re(str "sre")` </a> 
+
+#### KSR.textopsx.msg_apply_changes() ####
+<a target='_blank' href='/docs/modules/devel/modules/textopsx.html#textopsx.f.msg_apply_changes'> `int msg_apply_changes()` </a> 
+
+#### KSR.textopsx.msg_set_buffer() ####
+<a target='_blank' href='/docs/modules/devel/modules/textopsx.html#textopsx.f.msg_set_buffer'> `int msg_set_buffer(str "obuf")` </a> 
+
+#### KSR.textopsx.remove_body() ####
+<a target='_blank' href='/docs/modules/devel/modules/textopsx.html#textopsx.f.remove_body'> `int remove_body()` </a> 
+
+#### KSR.textopsx.remove_hf_value() ####
+<a target='_blank' href='/docs/modules/devel/modules/textopsx.html#textopsx.f.remove_hf_value'> `int remove_hf_value(str "hexp")` </a> 
+
+#### KSR.textopsx.remove_hf_value2() ####
+<a target='_blank' href='/docs/modules/devel/modules/textopsx.html#textopsx.f.remove_hf_value2'> `int remove_hf_value2(str "hexp", str "val")` </a> 
+
+## tls ##
+#### KSR.tls.is_peer_verified() ####
+<a target='_blank' href='/docs/modules/devel/modules/tls.html#tls.f.is_peer_verified'> `int is_peer_verified()` </a> 
+
 ## tm ##
 #### KSR.tm.t_any_replied() ####
-KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/tm.html#tm.f.t_any_replied'> `int t_any_replied()` </a> 
+<a target='_blank' href='/docs/modules/devel/modules/tm.html#tm.f.t_any_replied'> `int t_any_replied()` </a> 
 
 #### KSR.tm.t_any_timeout() ####
-KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/tm.html#tm.f.t_any_timeout'> `int t_any_timeout()` </a> 
+<a target='_blank' href='/docs/modules/devel/modules/tm.html#tm.f.t_any_timeout'> `int t_any_timeout()` </a> 
 
 #### KSR.tm.t_branch_replied() ####
-KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/tm.html#tm.f.t_branch_replied'> `int t_branch_replied()` </a> 
+<a target='_blank' href='/docs/modules/devel/modules/tm.html#tm.f.t_branch_replied'> `int t_branch_replied()` </a> 
 
 #### KSR.tm.t_branch_timeout() ####
-KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/tm.html#tm.f.t_branch_timeout'> `int t_branch_timeout()` </a> 
+<a target='_blank' href='/docs/modules/devel/modules/tm.html#tm.f.t_branch_timeout'> `int t_branch_timeout()` </a> 
 
 #### KSR.tm.t_check_trans() ####
-KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/tm.html#tm.f.t_check_trans'> `int t_check_trans()` </a> 
+<a target='_blank' href='/docs/modules/devel/modules/tm.html#tm.f.t_check_trans'> `int t_check_trans()` </a> 
 
 #### KSR.tm.t_drop_replies() ####
-KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/tm.html#tm.f.t_drop_replies'> `int t_drop_replies(str)` </a> 
+<a target='_blank' href='/docs/modules/devel/modules/tm.html#tm.f.t_drop_replies'> `int t_drop_replies(str "mode")` </a> 
 
-Docs declaration: `int t_drop_replies([mode])`
 #### KSR.tm.t_drop_replies_all() ####
-KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/tm.html#tm.f.t_drop_replies_all'> `int t_drop_replies_all()` </a> 
+<a target='_blank' href='/docs/modules/devel/modules/tm.html#tm.f.t_drop_replies_all'> `int t_drop_replies_all()` </a> 
 
 #### KSR.tm.t_grep_status() ####
-KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/tm.html#tm.f.t_grep_status'> `int t_grep_status(int)` </a> 
+<a target='_blank' href='/docs/modules/devel/modules/tm.html#tm.f.t_grep_status'> `int t_grep_status(int code)` </a> 
 
-Docs declaration: `int t_grep_status("code")`
 #### KSR.tm.t_is_canceled() ####
-KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/tm.html#tm.f.t_is_canceled'> `int t_is_canceled()` </a> 
+<a target='_blank' href='/docs/modules/devel/modules/tm.html#tm.f.t_is_canceled'> `int t_is_canceled()` </a> 
 
 #### KSR.tm.t_is_expired() ####
-KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/tm.html#tm.f.t_is_expired'> `int t_is_expired()` </a> 
+<a target='_blank' href='/docs/modules/devel/modules/tm.html#tm.f.t_is_expired'> `int t_is_expired()` </a> 
 
 #### KSR.tm.t_is_retr_async_reply() ####
-KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/tm.html#tm.f.t_is_retr_async_reply'> `int t_is_retr_async_reply()` </a> 
+<a target='_blank' href='/docs/modules/devel/modules/tm.html#tm.f.t_is_retr_async_reply'> `int t_is_retr_async_reply()` </a> 
 
 #### KSR.tm.t_is_set() ####
-KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/tm.html#tm.f.t_is_set'> `int t_is_set(str)` </a> 
+<a target='_blank' href='/docs/modules/devel/modules/tm.html#tm.f.t_is_set'> `int t_is_set(str "target")` </a> 
 
-Docs declaration: `int t_is_set(target)`
 #### KSR.tm.t_load_contacts() ####
-KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/tm.html#tm.f.t_load_contacts'> `int t_load_contacts()` </a> 
+<a target='_blank' href='/docs/modules/devel/modules/tm.html#tm.f.t_load_contacts'> `int t_load_contacts()` </a> 
 
 #### KSR.tm.t_lookup_cancel() ####
-KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/tm.html#tm.f.t_lookup_cancel'> `int t_lookup_cancel()` </a> 
+<a target='_blank' href='/docs/modules/devel/modules/tm.html#tm.f.t_lookup_cancel'> `int t_lookup_cancel()` </a> 
 
 #### KSR.tm.t_lookup_cancel_flags() ####
-KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/tm.html#tm.f.t_lookup_cancel_flags'> `int t_lookup_cancel_flags(int)` </a> 
+<a target='_blank' href='/docs/modules/devel/modules/tm.html#tm.f.t_lookup_cancel_flags'> `int t_lookup_cancel_flags(int flags)` </a> 
 
 #### KSR.tm.t_lookup_request() ####
-KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/tm.html#tm.f.t_lookup_request'> `int t_lookup_request()` </a> 
+<a target='_blank' href='/docs/modules/devel/modules/tm.html#tm.f.t_lookup_request'> `int t_lookup_request()` </a> 
 
 #### KSR.tm.t_newtran() ####
-KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/tm.html#tm.f.t_newtran'> `int t_newtran()` </a> 
+<a target='_blank' href='/docs/modules/devel/modules/tm.html#tm.f.t_newtran'> `int t_newtran()` </a> 
 
 #### KSR.tm.t_next_contact_flow() ####
-KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/tm.html#tm.f.t_next_contact_flow'> `int t_next_contact_flow()` </a> 
+<a target='_blank' href='/docs/modules/devel/modules/tm.html#tm.f.t_next_contact_flow'> `int t_next_contact_flow()` </a> 
 
 #### KSR.tm.t_next_contacts() ####
-KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/tm.html#tm.f.t_next_contacts'> `int t_next_contacts()` </a> 
+<a target='_blank' href='/docs/modules/devel/modules/tm.html#tm.f.t_next_contacts'> `int t_next_contacts()` </a> 
 
 #### KSR.tm.t_on_branch() ####
-KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/tm.html#tm.f.t_on_branch'> `int t_on_branch(str)` </a> 
+<a target='_blank' href='/docs/modules/devel/modules/tm.html#tm.f.t_on_branch'> `int t_on_branch(str "rname")` </a> 
 
-Docs declaration: `int t_on_branch(branch_route)`
 #### KSR.tm.t_on_branch_failure() ####
-KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/tm.html#tm.f.t_on_branch_failure'> `int t_on_branch_failure(str)` </a> 
+<a target='_blank' href='/docs/modules/devel/modules/tm.html#tm.f.t_on_branch_failure'> `int t_on_branch_failure(str "rname")` </a> 
 
-Docs declaration: `int t_on_branch_failure(branch_failure_route)`
 #### KSR.tm.t_on_failure() ####
-KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/tm.html#tm.f.t_on_failure'> `int t_on_failure(str)` </a> 
+<a target='_blank' href='/docs/modules/devel/modules/tm.html#tm.f.t_on_failure'> `int t_on_failure(str "rname")` </a> 
 
-Docs declaration: `int t_on_failure(failure_route)`
 #### KSR.tm.t_on_reply() ####
-KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/tm.html#tm.f.t_on_reply'> `int t_on_reply(str)` </a> 
+<a target='_blank' href='/docs/modules/devel/modules/tm.html#tm.f.t_on_reply'> `int t_on_reply(str "rname")` </a> 
 
-Docs declaration: `int t_on_reply(onreply_route)`
 #### KSR.tm.t_relay() ####
-KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/tm.html#tm.f.t_relay'> `int t_relay()` </a> 
+<a target='_blank' href='/docs/modules/devel/modules/tm.html#tm.f.t_relay'> `int t_relay()` </a> 
 
 #### KSR.tm.t_release() ####
-KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/tm.html#tm.f.t_release'> `int t_release()` </a> 
+<a target='_blank' href='/docs/modules/devel/modules/tm.html#tm.f.t_release'> `int t_release()` </a> 
 
 #### KSR.tm.t_replicate() ####
-KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/tm.html#tm.f.t_replicate'> `int t_replicate(str)` </a> 
+<a target='_blank' href='/docs/modules/devel/modules/tm.html#tm.f.t_replicate'> `int t_replicate(str "suri")` </a> 
 
-Docs declaration: `int t_replicate([params])`
 #### KSR.tm.t_reply() ####
-KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/tm.html#tm.f.t_reply'> `int t_reply(int, str)` </a> 
+<a target='_blank' href='/docs/modules/devel/modules/tm.html#tm.f.t_reply'> `int t_reply(int code, str "reason")` </a> 
 
-Docs declaration: `int t_reply(code, reason_phrase)`
 #### KSR.tm.t_reset_fr() ####
-KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/tm.html#tm.f.t_reset_fr'> `int t_reset_fr()` </a> 
+<a target='_blank' href='/docs/modules/devel/modules/tm.html#tm.f.t_reset_fr'> `int t_reset_fr()` </a> 
 
 #### KSR.tm.t_reset_max_lifetime() ####
-KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/tm.html#tm.f.t_reset_max_lifetime'> `int t_reset_max_lifetime()` </a> 
+<a target='_blank' href='/docs/modules/devel/modules/tm.html#tm.f.t_reset_max_lifetime'> `int t_reset_max_lifetime()` </a> 
 
 #### KSR.tm.t_reset_retr() ####
-KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/tm.html#tm.f.t_reset_retr'> `int t_reset_retr()` </a> 
+<a target='_blank' href='/docs/modules/devel/modules/tm.html#tm.f.t_reset_retr'> `int t_reset_retr()` </a> 
 
 #### KSR.tm.t_retransmit_reply() ####
-KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/tm.html#tm.f.t_retransmit_reply'> `int t_retransmit_reply()` </a> 
+<a target='_blank' href='/docs/modules/devel/modules/tm.html#tm.f.t_retransmit_reply'> `int t_retransmit_reply()` </a> 
 
 #### KSR.tm.t_save_lumps() ####
-KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/tm.html#tm.f.t_save_lumps'> `int t_save_lumps()` </a> 
+<a target='_blank' href='/docs/modules/devel/modules/tm.html#tm.f.t_save_lumps'> `int t_save_lumps()` </a> 
 
 #### KSR.tm.t_set_auto_inv_100() ####
-KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/tm.html#tm.f.t_set_auto_inv_100'> `int t_set_auto_inv_100(int)` </a> 
+<a target='_blank' href='/docs/modules/devel/modules/tm.html#tm.f.t_set_auto_inv_100'> `int t_set_auto_inv_100(int state)` </a> 
 
-Docs declaration: `int t_set_auto_inv_100(0|1)`
 #### KSR.tm.t_set_disable_6xx() ####
-KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/tm.html#tm.f.t_set_disable_6xx'> `int t_set_disable_6xx(int)` </a> 
+<a target='_blank' href='/docs/modules/devel/modules/tm.html#tm.f.t_set_disable_6xx'> `int t_set_disable_6xx(int state)` </a> 
 
-Docs declaration: `int t_set_disable_6xx(0|1)`
 #### KSR.tm.t_set_disable_failover() ####
-KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/tm.html#tm.f.t_set_disable_failover'> `int t_set_disable_failover(int)` </a> 
+<a target='_blank' href='/docs/modules/devel/modules/tm.html#tm.f.t_set_disable_failover'> `int t_set_disable_failover(int state)` </a> 
 
-Docs declaration: `int t_set_disable_failover(0|1)`
 #### KSR.tm.t_set_disable_internal_reply() ####
-KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/tm.html#tm.f.t_set_disable_internal_reply'> `int t_set_disable_internal_reply(int)` </a> 
+<a target='_blank' href='/docs/modules/devel/modules/tm.html#tm.f.t_set_disable_internal_reply'> `int t_set_disable_internal_reply(int state)` </a> 
 
-Docs declaration: `int t_set_disable_internal_reply(0|1)`
 #### KSR.tm.t_set_fr() ####
-KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/tm.html#tm.f.t_set_fr'> `int t_set_fr(int, int)` </a> 
+<a target='_blank' href='/docs/modules/devel/modules/tm.html#tm.f.t_set_fr'> `int t_set_fr(int fr_inv, int fr)` </a> 
 
-Docs declaration: `int t_set_fr(fr_inv_timeout [, fr_timeout])`
 #### KSR.tm.t_set_fr_inv() ####
-KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/tm.html#tm.f.t_set_fr_inv'> `int t_set_fr_inv(int)` </a> 
+<a target='_blank' href='/docs/modules/devel/modules/tm.html#tm.f.t_set_fr_inv'> `int t_set_fr_inv(int fr_inv)` </a> 
 
 #### KSR.tm.t_set_max_lifetime() ####
-KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/tm.html#tm.f.t_set_max_lifetime'> `int t_set_max_lifetime(int, int)` </a> 
+<a target='_blank' href='/docs/modules/devel/modules/tm.html#tm.f.t_set_max_lifetime'> `int t_set_max_lifetime(int t1, int t2)` </a> 
 
-Docs declaration: `int t_set_max_lifetime(inv_lifetime, noninv_lifetime)`
 #### KSR.tm.t_set_no_e2e_cancel_reason() ####
-KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/tm.html#tm.f.t_set_no_e2e_cancel_reason'> `int t_set_no_e2e_cancel_reason(int)` </a> 
+<a target='_blank' href='/docs/modules/devel/modules/tm.html#tm.f.t_set_no_e2e_cancel_reason'> `int t_set_no_e2e_cancel_reason(int state)` </a> 
 
-Docs declaration: `int t_set_no_e2e_cancel_reason(0|1)`
 #### KSR.tm.t_set_retr() ####
-KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/tm.html#tm.f.t_set_retr'> `int t_set_retr(int, int)` </a> 
+<a target='_blank' href='/docs/modules/devel/modules/tm.html#tm.f.t_set_retr'> `int t_set_retr(int t1, int t2)` </a> 
 
-Docs declaration: `int t_set_retr(retr_t1_interval, retr_t2_interval)`
 #### KSR.tm.t_uac_send() ####
-KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/tm.html#tm.f.t_uac_send'> `int t_uac_send(str, str, str, str, str, str)` </a> 
+<a target='_blank' href='/docs/modules/devel/modules/tm.html#tm.f.t_uac_send'> `int t_uac_send(str "method", str "ruri", str "nexthop", str "ssock", str "hdrs", str "body")` </a> 
 
-Docs declaration: `int t_uac_send(method, ruri, nexthop, socket, headers,)`
 #### KSR.tm.t_use_uac_headers() ####
-KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/tm.html#tm.f.t_use_uac_headers'> `int t_use_uac_headers()` </a> 
+<a target='_blank' href='/docs/modules/devel/modules/tm.html#tm.f.t_use_uac_headers'> `int t_use_uac_headers()` </a> 
 
 ## tmx ##
 #### KSR.tmx.t_is_branch_route() ####
-KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/tmx.html#tmx.f.t_is_branch_route'> `int t_is_branch_route()` </a> 
+<a target='_blank' href='/docs/modules/devel/modules/tmx.html#tmx.f.t_is_branch_route'> `int t_is_branch_route()` </a> 
 
 #### KSR.tmx.t_is_failure_route() ####
-KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/tmx.html#tmx.f.t_is_failure_route'> `int t_is_failure_route()` </a> 
+<a target='_blank' href='/docs/modules/devel/modules/tmx.html#tmx.f.t_is_failure_route'> `int t_is_failure_route()` </a> 
 
 #### KSR.tmx.t_is_reply_route() ####
-KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/tmx.html#tmx.f.t_is_reply_route'> `int t_is_reply_route()` </a> 
+<a target='_blank' href='/docs/modules/devel/modules/tmx.html#tmx.f.t_is_reply_route'> `int t_is_reply_route()` </a> 
 
 #### KSR.tmx.t_is_request_route() ####
-KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/tmx.html#tmx.f.t_is_request_route'> `int t_is_request_route()` </a> 
+<a target='_blank' href='/docs/modules/devel/modules/tmx.html#tmx.f.t_is_request_route'> `int t_is_request_route()` </a> 
 
 #### KSR.tmx.t_precheck_trans() ####
-KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/tmx.html#tmx.f.t_precheck_trans'> `int t_precheck_trans()` </a> 
+<a target='_blank' href='/docs/modules/devel/modules/tmx.html#tmx.f.t_precheck_trans'> `int t_precheck_trans()` </a> 
+
+## tsilo ##
+#### KSR.tsilo.ts_append() ####
+<a target='_blank' href='/docs/modules/devel/modules/tsilo.html#tsilo.f.ts_append'> `int ts_append(str "_table", str "_ruri")` </a> 
+
+#### KSR.tsilo.ts_append_to() ####
+<a target='_blank' href='/docs/modules/devel/modules/tsilo.html#tsilo.f.ts_append_to'> `int ts_append_to(int tindex, int tlabel, str "_table")` </a> 
+
+#### KSR.tsilo.ts_append_to_uri() ####
+<a target='_blank' href='/docs/modules/devel/modules/tsilo.html#tsilo.f.ts_append_to_uri'> `int ts_append_to_uri(int tindex, int tlabel, str "_table", str "_uri")` </a> 
+
+#### KSR.tsilo.ts_store() ####
+<a target='_blank' href='/docs/modules/devel/modules/tsilo.html#tsilo.f.ts_store'> `int ts_store()` </a> 
+
+#### KSR.tsilo.ts_store_uri() ####
+<a target='_blank' href='/docs/modules/devel/modules/tsilo.html#tsilo.f.ts_store_uri'> `int ts_store_uri(str "puri")` </a> 
+
+## uac ##
+#### KSR.uac.uac_auth() ####
+<a target='_blank' href='/docs/modules/devel/modules/uac.html#uac.f.uac_auth'> `int uac_auth()` </a> 
+
+#### KSR.uac.uac_reg_lookup() ####
+<a target='_blank' href='/docs/modules/devel/modules/uac.html#uac.f.uac_reg_lookup'> `int uac_reg_lookup(str "userid", str "sdst")` </a> 
+
+#### KSR.uac.uac_reg_request_to() ####
+<a target='_blank' href='/docs/modules/devel/modules/uac.html#uac.f.uac_reg_request_to'> `int uac_reg_request_to(str "userid", int imode)` </a> 
+
+#### KSR.uac.uac_reg_status() ####
+<a target='_blank' href='/docs/modules/devel/modules/uac.html#uac.f.uac_reg_status'> `int uac_reg_status(str "sruuid")` </a> 
+
+#### KSR.uac.uac_replace_from() ####
+<a target='_blank' href='/docs/modules/devel/modules/uac.html#uac.f.uac_replace_from'> `int uac_replace_from(str "pdsp", str "puri")` </a> 
+
+#### KSR.uac.uac_replace_from_uri() ####
+<a target='_blank' href='/docs/modules/devel/modules/uac.html#uac.f.uac_replace_from_uri'> `int uac_replace_from_uri(str "puri")` </a> 
+
+#### KSR.uac.uac_replace_to() ####
+<a target='_blank' href='/docs/modules/devel/modules/uac.html#uac.f.uac_replace_to'> `int uac_replace_to(str "pdsp", str "puri")` </a> 
+
+#### KSR.uac.uac_replace_to_uri() ####
+<a target='_blank' href='/docs/modules/devel/modules/uac.html#uac.f.uac_replace_to_uri'> `int uac_replace_to_uri(str "puri")` </a> 
+
+#### KSR.uac.uac_req_send() ####
+<a target='_blank' href='/docs/modules/devel/modules/uac.html#uac.f.uac_req_send'> `int uac_req_send()` </a> 
+
+#### KSR.uac.uac_restore_from() ####
+<a target='_blank' href='/docs/modules/devel/modules/uac.html#uac.f.uac_restore_from'> `int uac_restore_from()` </a> 
+
+#### KSR.uac.uac_restore_to() ####
+<a target='_blank' href='/docs/modules/devel/modules/uac.html#uac.f.uac_restore_to'> `int uac_restore_to()` </a> 
+
+## utils ##
+#### KSR.utils.xcap_auth_status() ####
+<a target='_blank' href='/docs/modules/devel/modules/utils.html#utils.f.xcap_auth_status'> `int xcap_auth_status(str "watcher_uri", str "presentity_uri")` </a> 
+
+## websocket ##
+#### KSR.websocket.close() ####
+<a target='_blank' href='/docs/modules/devel/modules/websocket.html#websocket.f.close'> `int close()` </a> 
+
+#### KSR.websocket.close_conid() ####
+<a target='_blank' href='/docs/modules/devel/modules/websocket.html#websocket.f.close_conid'> `int close_conid(int status, str "reason", int con)` </a> 
+
+#### KSR.websocket.close_reason() ####
+<a target='_blank' href='/docs/modules/devel/modules/websocket.html#websocket.f.close_reason'> `int close_reason(int status, str "reason")` </a> 
+
+#### KSR.websocket.handle_handshake() ####
+<a target='_blank' href='/docs/modules/devel/modules/websocket.html#websocket.f.handle_handshake'> `int handle_handshake()` </a> 
+
+## xcap_server ##
+#### KSR.xcap_server.xcaps_del() ####
+<a target='_blank' href='/docs/modules/devel/modules/xcap_server.html#xcap_server.f.xcaps_del'> `int xcaps_del(str "uri", str "path")` </a> 
+
+#### KSR.xcap_server.xcaps_get() ####
+<a target='_blank' href='/docs/modules/devel/modules/xcap_server.html#xcap_server.f.xcaps_get'> `int xcaps_get(str "uri", str "path")` </a> 
+
+#### KSR.xcap_server.xcaps_put() ####
+<a target='_blank' href='/docs/modules/devel/modules/xcap_server.html#xcap_server.f.xcaps_put'> `int xcaps_put(str "uri", str "path", str "pbody")` </a> 
+
+## xhttp ##
+#### KSR.xhttp.xhttp_reply() ####
+<a target='_blank' href='/docs/modules/devel/modules/xhttp.html#xhttp.f.xhttp_reply'> `int xhttp_reply(int code, str "reason", str "ctype", str "body")` </a> 
+
+## xhttp_pi ##
+#### KSR.xhttp_pi.dispatch() ####
+<a target='_blank' href='/docs/modules/devel/modules/xhttp_pi.html#xhttp_pi.f.dispatch'> `int dispatch()` </a> 
+
+## xhttp_rpc ##
+#### KSR.xhttp_rpc.dispatch() ####
+<a target='_blank' href='/docs/modules/devel/modules/xhttp_rpc.html#xhttp_rpc.f.dispatch'> `int dispatch()` </a> 
 
 ## xlog ##
 #### KSR.xlog.xalert() ####
-KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/xlog.html#xlog.f.xalert'> `int xalert(str)` </a> 
+<a target='_blank' href='/docs/modules/devel/modules/xlog.html#xlog.f.xalert'> `int xalert(str "lmsg")` </a> 
 
-Docs declaration: `int xalert(format)`
 #### KSR.xlog.xcrit() ####
-KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/xlog.html#xlog.f.xcrit'> `int xcrit(str)` </a> 
+<a target='_blank' href='/docs/modules/devel/modules/xlog.html#xlog.f.xcrit'> `int xcrit(str "lmsg")` </a> 
 
-Docs declaration: `int xcrit(format)`
 #### KSR.xlog.xdbg() ####
-KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/xlog.html#xlog.f.xdbg'> `int xdbg(str)` </a> 
+<a target='_blank' href='/docs/modules/devel/modules/xlog.html#xlog.f.xdbg'> `int xdbg(str "lmsg")` </a> 
 
-Docs declaration: `int xdbg(format)`
 #### KSR.xlog.xerr() ####
-KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/xlog.html#xlog.f.xerr'> `int xerr(str)` </a> 
+<a target='_blank' href='/docs/modules/devel/modules/xlog.html#xlog.f.xerr'> `int xerr(str "lmsg")` </a> 
 
-Docs declaration: `int xerr(format)`
 #### KSR.xlog.xinfo() ####
-KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/xlog.html#xlog.f.xinfo'> `int xinfo(str)` </a> 
+<a target='_blank' href='/docs/modules/devel/modules/xlog.html#xlog.f.xinfo'> `int xinfo(str "lmsg")` </a> 
 
-Docs declaration: `int xinfo(format)`
 #### KSR.xlog.xlog() ####
-KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/xlog.html#xlog.f.xlog'> `int xlog(str, str)` </a> 
+<a target='_blank' href='/docs/modules/devel/modules/xlog.html#xlog.f.xlog'> `int xlog(str "slevel", str "lmsg")` </a> 
 
-Docs declaration: `int xlog([ [facility,] level,] format)`
 #### KSR.xlog.xnotice() ####
-KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/xlog.html#xlog.f.xnotice'> `int xnotice(str)` </a> 
+<a target='_blank' href='/docs/modules/devel/modules/xlog.html#xlog.f.xnotice'> `int xnotice(str "lmsg")` </a> 
 
-Docs declaration: `int xnotice(format)`
 #### KSR.xlog.xwarn() ####
-KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/xlog.html#xlog.f.xwarn'> `int xwarn(str)` </a> 
+<a target='_blank' href='/docs/modules/devel/modules/xlog.html#xlog.f.xwarn'> `int xwarn(str "lmsg")` </a> 
 
-Docs declaration: `int xwarn(format)`
+## xmlrpc ##
+#### KSR.xmlrpc.dispatch_rpc() ####
+<a target='_blank' href='/docs/modules/devel/modules/xmlrpc.html#xmlrpc.f.dispatch_rpc'> `int dispatch_rpc()` </a> 
+
+#### KSR.xmlrpc.xmlrpc_reply() ####
+<a target='_blank' href='/docs/modules/devel/modules/xmlrpc.html#xmlrpc.f.xmlrpc_reply'> `int xmlrpc_reply(int rcode, str "reason")` </a> 
+

--- a/kamailio-kemi-framework/docs/modules.md
+++ b/kamailio-kemi-framework/docs/modules.md
@@ -1,0 +1,436 @@
+<!-- This file is auto-generated. Any manual modifications will be deleted -->
+# KEMI Module Functions #
+The following sections lists all exported KEMI functions. More information regarding the function can be found by clicking the KEMI declaration which will take you the original modules documentation. 
+## app_python ##
+#### KSR.app_python.exec() ####
+KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/app_python.html#app_python.f.exec'> `int exec(str)` </a> 
+
+Docs declaration: `int exec(method [, args])`
+#### KSR.app_python.exec_p1() ####
+KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/app_python.html#app_python.f.exec_p1'> `int exec_p1(str, str)` </a> 
+
+## corex ##
+#### KSR.corex.append_branch() ####
+KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/corex.html#corex.f.append_branch'> `int append_branch()` </a> 
+
+#### KSR.corex.append_branch_uri() ####
+KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/corex.html#corex.f.append_branch_uri'> `int append_branch_uri(str)` </a> 
+
+#### KSR.corex.append_branch_uri_q() ####
+KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/corex.html#corex.f.append_branch_uri_q'> `int append_branch_uri_q(str, str)` </a> 
+
+## jsonrpcs ##
+#### KSR.jsonrpcs.exec() ####
+KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/jsonrpcs.html#jsonrpcs.f.exec'> `int exec(str)` </a> 
+
+Docs declaration: `int exec(cmd)`
+## kex ##
+#### KSR.kex.resetdebug() ####
+KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/kex.html#kex.f.resetdebug'> `int resetdebug(str, str)` </a> 
+
+#### KSR.kex.setdebug() ####
+KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/kex.html#kex.f.setdebug'> `int setdebug(int)` </a> 
+
+Docs declaration: `int setdebug(level)`
+## maxfwd ##
+#### KSR.maxfwd.process_maxfwd() ####
+KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/maxfwd.html#maxfwd.f.process_maxfwd'> `int process_maxfwd(int)` </a> 
+
+Docs declaration: `int process_maxfwd(max_value)`
+## pvx ##
+#### KSR.pvx.evalx() ####
+KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/pvx.html#pvx.f.evalx'> `int evalx(str, str)` </a> 
+
+#### KSR.pvx.pv_var_to_xavp() ####
+KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/pvx.html#pvx.f.pv_var_to_xavp'> `int pv_var_to_xavp(str, str)` </a> 
+
+#### KSR.pvx.pv_xavp_print() ####
+KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/pvx.html#pvx.f.pv_xavp_print'> `int pv_xavp_print()` </a> 
+
+#### KSR.pvx.pv_xavp_to_var() ####
+KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/pvx.html#pvx.f.pv_xavp_to_var'> `int pv_xavp_to_var(str)` </a> 
+
+#### KSR.pvx.sbranch_append() ####
+KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/pvx.html#pvx.f.sbranch_append'> `int sbranch_append()` </a> 
+
+#### KSR.pvx.sbranch_reset() ####
+KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/pvx.html#pvx.f.sbranch_reset'> `int sbranch_reset()` </a> 
+
+#### KSR.pvx.sbranch_set_ruri() ####
+KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/pvx.html#pvx.f.sbranch_set_ruri'> `int sbranch_set_ruri()` </a> 
+
+#### KSR.pvx.xavp_params_explode() ####
+KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/pvx.html#pvx.f.xavp_params_explode'> `int xavp_params_explode(str, str)` </a> 
+
+## rr ##
+#### KSR.rr.add_rr_param() ####
+KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/rr.html#rr.f.add_rr_param'> `int add_rr_param(str)` </a> 
+
+Docs declaration: `int add_rr_param()`
+#### KSR.rr.check_route_param() ####
+KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/rr.html#rr.f.check_route_param'> `int check_route_param(str)` </a> 
+
+Docs declaration: `int check_route_param(re)`
+#### KSR.rr.loose_route() ####
+KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/rr.html#rr.f.loose_route'> `int loose_route()` </a> 
+
+#### KSR.rr.record_route() ####
+KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/rr.html#rr.f.record_route'> `int record_route()` </a> 
+
+#### KSR.rr.record_route_params() ####
+KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/rr.html#rr.f.record_route_params'> `int record_route_params(str)` </a> 
+
+#### KSR.rr.remove_record_route() ####
+KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/rr.html#rr.f.remove_record_route'> `int remove_record_route()` </a> 
+
+## sanity ##
+#### KSR.sanity.sanity_check() ####
+KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/sanity.html#sanity.f.sanity_check'> `int sanity_check(int, int)` </a> 
+
+Docs declaration: `int sanity_check([msg_checks [, uri_checks]])`
+#### KSR.sanity.sanity_check_defaults() ####
+KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/sanity.html#sanity.f.sanity_check_defaults'> `int sanity_check_defaults()` </a> 
+
+## siputils ##
+#### KSR.siputils.has_totag() ####
+KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/siputils.html#siputils.f.has_totag'> `int has_totag()` </a> 
+
+#### KSR.siputils.is_first_hop() ####
+KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/siputils.html#siputils.f.is_first_hop'> `int is_first_hop()` </a> 
+
+#### KSR.siputils.is_reply() ####
+KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/siputils.html#siputils.f.is_reply'> `int is_reply()` </a> 
+
+#### KSR.siputils.is_request() ####
+KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/siputils.html#siputils.f.is_request'> `int is_request()` </a> 
+
+## sl ##
+#### KSR.sl.send_reply() ####
+KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/sl.html#sl.f.send_reply'> `int send_reply(int, str)` </a> 
+
+Docs declaration: `int send_reply(code, reason)`
+#### KSR.sl.sl_forward_reply() ####
+KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/sl.html#sl.f.sl_forward_reply'> `int sl_forward_reply(str, str)` </a> 
+
+Docs declaration: `int sl_forward_reply("404", "Not found")`
+#### KSR.sl.sl_reply_error() ####
+KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/sl.html#sl.f.sl_reply_error'> `int sl_reply_error()` </a> 
+
+#### KSR.sl.sl_send_reply() ####
+KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/sl.html#sl.f.sl_send_reply'> `int sl_send_reply(int, str)` </a> 
+
+Docs declaration: `int sl_send_reply(code, reason)`
+## textops ##
+#### KSR.textops.cmp_istr() ####
+KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/textops.html#textops.f.cmp_istr'> `int cmp_istr(str, str)` </a> 
+
+Docs declaration: `int cmp_istr(str1, str2)`
+#### KSR.textops.cmp_str() ####
+KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/textops.html#textops.f.cmp_str'> `int cmp_str(str, str)` </a> 
+
+Docs declaration: `int cmp_str(str1, str2)`
+#### KSR.textops.filter_body() ####
+KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/textops.html#textops.f.filter_body'> `int filter_body(str)` </a> 
+
+Docs declaration: `int filter_body(content_type)`
+#### KSR.textops.has_body() ####
+KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/textops.html#textops.f.has_body'> `int has_body()` </a> 
+
+#### KSR.textops.has_body_type() ####
+KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/textops.html#textops.f.has_body_type'> `int has_body_type(str)` </a> 
+
+#### KSR.textops.is_audio_on_hold() ####
+KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/textops.html#textops.f.is_audio_on_hold'> `int is_audio_on_hold()` </a> 
+
+#### KSR.textops.is_list() ####
+KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/textops.html#textops.f.is_list'> `int is_list(str, str, str)` </a> 
+
+#### KSR.textops.is_present_hf() ####
+KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/textops.html#textops.f.is_present_hf'> `int is_present_hf(str)` </a> 
+
+Docs declaration: `int is_present_hf(hf_name)`
+#### KSR.textops.is_present_hf_re() ####
+KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/textops.html#textops.f.is_present_hf_re'> `int is_present_hf_re(str)` </a> 
+
+Docs declaration: `int is_present_hf_re(hf_name_re)`
+#### KSR.textops.is_privacy() ####
+KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/textops.html#textops.f.is_privacy'> `int is_privacy(str)` </a> 
+
+Docs declaration: `int is_privacy(privacy_type)`
+#### KSR.textops.remove_hf_exp() ####
+KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/textops.html#textops.f.remove_hf_exp'> `int remove_hf_exp(str, str)` </a> 
+
+Docs declaration: `int remove_hf_exp(expmatch, expskip)`
+#### KSR.textops.remove_hf_re() ####
+KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/textops.html#textops.f.remove_hf_re'> `int remove_hf_re(str)` </a> 
+
+Docs declaration: `int remove_hf_re(re)`
+#### KSR.textops.replace() ####
+KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/textops.html#textops.f.replace'> `int replace(str, str)` </a> 
+
+Docs declaration: `int replace(re, txt)`
+#### KSR.textops.replace_all() ####
+KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/textops.html#textops.f.replace_all'> `int replace_all(str, str)` </a> 
+
+Docs declaration: `int replace_all(re, txt)`
+#### KSR.textops.replace_body() ####
+KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/textops.html#textops.f.replace_body'> `int replace_body(str, str)` </a> 
+
+Docs declaration: `int replace_body(re, txt)`
+#### KSR.textops.replace_body_all() ####
+KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/textops.html#textops.f.replace_body_all'> `int replace_body_all(str, str)` </a> 
+
+Docs declaration: `int replace_body_all(re, txt)`
+#### KSR.textops.replace_body_atonce() ####
+KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/textops.html#textops.f.replace_body_atonce'> `int replace_body_atonce(str, str)` </a> 
+
+Docs declaration: `int replace_body_atonce(re, txt)`
+#### KSR.textops.search() ####
+KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/textops.html#textops.f.search'> `int search(str)` </a> 
+
+Docs declaration: `int search(re)`
+#### KSR.textops.search_append() ####
+KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/textops.html#textops.f.search_append'> `int search_append(str)` </a> 
+
+Docs declaration: `int search_append(re, txt)`
+#### KSR.textops.search_append_body() ####
+KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/textops.html#textops.f.search_append_body'> `int search_append_body(str)` </a> 
+
+Docs declaration: `int search_append_body(re, txt)`
+#### KSR.textops.search_body() ####
+KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/textops.html#textops.f.search_body'> `int search_body(str)` </a> 
+
+Docs declaration: `int search_body(re)`
+#### KSR.textops.search_hf() ####
+KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/textops.html#textops.f.search_hf'> `int search_hf(str, str, str)` </a> 
+
+Docs declaration: `int search_hf(hf, re, flags)`
+#### KSR.textops.set_body() ####
+KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/textops.html#textops.f.set_body'> `int set_body(str, str)` </a> 
+
+Docs declaration: `int set_body(txt,content_type)`
+#### KSR.textops.set_reply_body() ####
+KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/textops.html#textops.f.set_reply_body'> `int set_reply_body(str, str)` </a> 
+
+Docs declaration: `int set_reply_body(txt,content_type)`
+#### KSR.textops.starts_with() ####
+KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/textops.html#textops.f.starts_with'> `int starts_with(str, str)` </a> 
+
+Docs declaration: `int starts_with(str1, str2)`
+#### KSR.textops.subst() ####
+KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/textops.html#textops.f.subst'> `int subst(str)` </a> 
+
+Docs declaration: `int subst('/re/repl/flags')`
+#### KSR.textops.subst_body() ####
+KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/textops.html#textops.f.subst_body'> `int subst_body(str)` </a> 
+
+Docs declaration: `int subst_body('/re/repl/flags')`
+#### KSR.textops.subst_hf() ####
+KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/textops.html#textops.f.subst_hf'> `int subst_hf(str, str, str)` </a> 
+
+Docs declaration: `int subst_hf(hf, subexp, flags)`
+#### KSR.textops.subst_uri() ####
+KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/textops.html#textops.f.subst_uri'> `int subst_uri(str)` </a> 
+
+Docs declaration: `int subst_uri('/re/repl/flags')`
+#### KSR.textops.subst_user() ####
+KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/textops.html#textops.f.subst_user'> `int subst_user(str)` </a> 
+
+Docs declaration: `int subst_user('/re/repl/flags')`
+## tm ##
+#### KSR.tm.t_any_replied() ####
+KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/tm.html#tm.f.t_any_replied'> `int t_any_replied()` </a> 
+
+#### KSR.tm.t_any_timeout() ####
+KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/tm.html#tm.f.t_any_timeout'> `int t_any_timeout()` </a> 
+
+#### KSR.tm.t_branch_replied() ####
+KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/tm.html#tm.f.t_branch_replied'> `int t_branch_replied()` </a> 
+
+#### KSR.tm.t_branch_timeout() ####
+KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/tm.html#tm.f.t_branch_timeout'> `int t_branch_timeout()` </a> 
+
+#### KSR.tm.t_check_trans() ####
+KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/tm.html#tm.f.t_check_trans'> `int t_check_trans()` </a> 
+
+#### KSR.tm.t_drop_replies() ####
+KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/tm.html#tm.f.t_drop_replies'> `int t_drop_replies(str)` </a> 
+
+Docs declaration: `int t_drop_replies([mode])`
+#### KSR.tm.t_drop_replies_all() ####
+KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/tm.html#tm.f.t_drop_replies_all'> `int t_drop_replies_all()` </a> 
+
+#### KSR.tm.t_grep_status() ####
+KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/tm.html#tm.f.t_grep_status'> `int t_grep_status(int)` </a> 
+
+Docs declaration: `int t_grep_status("code")`
+#### KSR.tm.t_is_canceled() ####
+KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/tm.html#tm.f.t_is_canceled'> `int t_is_canceled()` </a> 
+
+#### KSR.tm.t_is_expired() ####
+KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/tm.html#tm.f.t_is_expired'> `int t_is_expired()` </a> 
+
+#### KSR.tm.t_is_retr_async_reply() ####
+KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/tm.html#tm.f.t_is_retr_async_reply'> `int t_is_retr_async_reply()` </a> 
+
+#### KSR.tm.t_is_set() ####
+KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/tm.html#tm.f.t_is_set'> `int t_is_set(str)` </a> 
+
+Docs declaration: `int t_is_set(target)`
+#### KSR.tm.t_load_contacts() ####
+KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/tm.html#tm.f.t_load_contacts'> `int t_load_contacts()` </a> 
+
+#### KSR.tm.t_lookup_cancel() ####
+KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/tm.html#tm.f.t_lookup_cancel'> `int t_lookup_cancel()` </a> 
+
+#### KSR.tm.t_lookup_cancel_flags() ####
+KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/tm.html#tm.f.t_lookup_cancel_flags'> `int t_lookup_cancel_flags(int)` </a> 
+
+#### KSR.tm.t_lookup_request() ####
+KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/tm.html#tm.f.t_lookup_request'> `int t_lookup_request()` </a> 
+
+#### KSR.tm.t_newtran() ####
+KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/tm.html#tm.f.t_newtran'> `int t_newtran()` </a> 
+
+#### KSR.tm.t_next_contact_flow() ####
+KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/tm.html#tm.f.t_next_contact_flow'> `int t_next_contact_flow()` </a> 
+
+#### KSR.tm.t_next_contacts() ####
+KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/tm.html#tm.f.t_next_contacts'> `int t_next_contacts()` </a> 
+
+#### KSR.tm.t_on_branch() ####
+KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/tm.html#tm.f.t_on_branch'> `int t_on_branch(str)` </a> 
+
+Docs declaration: `int t_on_branch(branch_route)`
+#### KSR.tm.t_on_branch_failure() ####
+KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/tm.html#tm.f.t_on_branch_failure'> `int t_on_branch_failure(str)` </a> 
+
+Docs declaration: `int t_on_branch_failure(branch_failure_route)`
+#### KSR.tm.t_on_failure() ####
+KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/tm.html#tm.f.t_on_failure'> `int t_on_failure(str)` </a> 
+
+Docs declaration: `int t_on_failure(failure_route)`
+#### KSR.tm.t_on_reply() ####
+KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/tm.html#tm.f.t_on_reply'> `int t_on_reply(str)` </a> 
+
+Docs declaration: `int t_on_reply(onreply_route)`
+#### KSR.tm.t_relay() ####
+KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/tm.html#tm.f.t_relay'> `int t_relay()` </a> 
+
+#### KSR.tm.t_release() ####
+KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/tm.html#tm.f.t_release'> `int t_release()` </a> 
+
+#### KSR.tm.t_replicate() ####
+KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/tm.html#tm.f.t_replicate'> `int t_replicate(str)` </a> 
+
+Docs declaration: `int t_replicate([params])`
+#### KSR.tm.t_reply() ####
+KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/tm.html#tm.f.t_reply'> `int t_reply(int, str)` </a> 
+
+Docs declaration: `int t_reply(code, reason_phrase)`
+#### KSR.tm.t_reset_fr() ####
+KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/tm.html#tm.f.t_reset_fr'> `int t_reset_fr()` </a> 
+
+#### KSR.tm.t_reset_max_lifetime() ####
+KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/tm.html#tm.f.t_reset_max_lifetime'> `int t_reset_max_lifetime()` </a> 
+
+#### KSR.tm.t_reset_retr() ####
+KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/tm.html#tm.f.t_reset_retr'> `int t_reset_retr()` </a> 
+
+#### KSR.tm.t_retransmit_reply() ####
+KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/tm.html#tm.f.t_retransmit_reply'> `int t_retransmit_reply()` </a> 
+
+#### KSR.tm.t_save_lumps() ####
+KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/tm.html#tm.f.t_save_lumps'> `int t_save_lumps()` </a> 
+
+#### KSR.tm.t_set_auto_inv_100() ####
+KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/tm.html#tm.f.t_set_auto_inv_100'> `int t_set_auto_inv_100(int)` </a> 
+
+Docs declaration: `int t_set_auto_inv_100(0|1)`
+#### KSR.tm.t_set_disable_6xx() ####
+KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/tm.html#tm.f.t_set_disable_6xx'> `int t_set_disable_6xx(int)` </a> 
+
+Docs declaration: `int t_set_disable_6xx(0|1)`
+#### KSR.tm.t_set_disable_failover() ####
+KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/tm.html#tm.f.t_set_disable_failover'> `int t_set_disable_failover(int)` </a> 
+
+Docs declaration: `int t_set_disable_failover(0|1)`
+#### KSR.tm.t_set_disable_internal_reply() ####
+KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/tm.html#tm.f.t_set_disable_internal_reply'> `int t_set_disable_internal_reply(int)` </a> 
+
+Docs declaration: `int t_set_disable_internal_reply(0|1)`
+#### KSR.tm.t_set_fr() ####
+KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/tm.html#tm.f.t_set_fr'> `int t_set_fr(int, int)` </a> 
+
+Docs declaration: `int t_set_fr(fr_inv_timeout [, fr_timeout])`
+#### KSR.tm.t_set_fr_inv() ####
+KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/tm.html#tm.f.t_set_fr_inv'> `int t_set_fr_inv(int)` </a> 
+
+#### KSR.tm.t_set_max_lifetime() ####
+KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/tm.html#tm.f.t_set_max_lifetime'> `int t_set_max_lifetime(int, int)` </a> 
+
+Docs declaration: `int t_set_max_lifetime(inv_lifetime, noninv_lifetime)`
+#### KSR.tm.t_set_no_e2e_cancel_reason() ####
+KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/tm.html#tm.f.t_set_no_e2e_cancel_reason'> `int t_set_no_e2e_cancel_reason(int)` </a> 
+
+Docs declaration: `int t_set_no_e2e_cancel_reason(0|1)`
+#### KSR.tm.t_set_retr() ####
+KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/tm.html#tm.f.t_set_retr'> `int t_set_retr(int, int)` </a> 
+
+Docs declaration: `int t_set_retr(retr_t1_interval, retr_t2_interval)`
+#### KSR.tm.t_uac_send() ####
+KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/tm.html#tm.f.t_uac_send'> `int t_uac_send(str, str, str, str, str, str)` </a> 
+
+Docs declaration: `int t_uac_send(method, ruri, nexthop, socket, headers,)`
+#### KSR.tm.t_use_uac_headers() ####
+KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/tm.html#tm.f.t_use_uac_headers'> `int t_use_uac_headers()` </a> 
+
+## tmx ##
+#### KSR.tmx.t_is_branch_route() ####
+KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/tmx.html#tmx.f.t_is_branch_route'> `int t_is_branch_route()` </a> 
+
+#### KSR.tmx.t_is_failure_route() ####
+KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/tmx.html#tmx.f.t_is_failure_route'> `int t_is_failure_route()` </a> 
+
+#### KSR.tmx.t_is_reply_route() ####
+KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/tmx.html#tmx.f.t_is_reply_route'> `int t_is_reply_route()` </a> 
+
+#### KSR.tmx.t_is_request_route() ####
+KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/tmx.html#tmx.f.t_is_request_route'> `int t_is_request_route()` </a> 
+
+#### KSR.tmx.t_precheck_trans() ####
+KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/tmx.html#tmx.f.t_precheck_trans'> `int t_precheck_trans()` </a> 
+
+## xlog ##
+#### KSR.xlog.xalert() ####
+KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/xlog.html#xlog.f.xalert'> `int xalert(str)` </a> 
+
+Docs declaration: `int xalert(format)`
+#### KSR.xlog.xcrit() ####
+KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/xlog.html#xlog.f.xcrit'> `int xcrit(str)` </a> 
+
+Docs declaration: `int xcrit(format)`
+#### KSR.xlog.xdbg() ####
+KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/xlog.html#xlog.f.xdbg'> `int xdbg(str)` </a> 
+
+Docs declaration: `int xdbg(format)`
+#### KSR.xlog.xerr() ####
+KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/xlog.html#xlog.f.xerr'> `int xerr(str)` </a> 
+
+Docs declaration: `int xerr(format)`
+#### KSR.xlog.xinfo() ####
+KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/xlog.html#xlog.f.xinfo'> `int xinfo(str)` </a> 
+
+Docs declaration: `int xinfo(format)`
+#### KSR.xlog.xlog() ####
+KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/xlog.html#xlog.f.xlog'> `int xlog(str, str)` </a> 
+
+Docs declaration: `int xlog([ [facility,] level,] format)`
+#### KSR.xlog.xnotice() ####
+KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/xlog.html#xlog.f.xnotice'> `int xnotice(str)` </a> 
+
+Docs declaration: `int xnotice(format)`
+#### KSR.xlog.xwarn() ####
+KEMI declaration: <a target='_blank' href='/docs/modules/devel/modules/xlog.html#xlog.f.xwarn'> `int xwarn(str)` </a> 
+
+Docs declaration: `int xwarn(format)`

--- a/kamailio-kemi-framework/docs/modules.md
+++ b/kamailio-kemi-framework/docs/modules.md
@@ -1,1470 +1,2029 @@
 <!-- This file is auto-generated. Any manual modifications will be deleted -->
 # KEMI Module Functions #
-The following sections lists all exported KEMI functions. More information regarding the function can be found by clicking the KEMI declaration which will take you the original modules documentation. 
-## acc ##
-#### KSR.acc.acc_db_request() ####
+The following sections lists all exported KEMI functions. More information regarding the function can be found by clicking the KEMI declaration which will take you the original modules documentation.
+
+## acc
+
+#### KSR.acc.acc_db_request()
+
 <a target='_blank' href='/docs/modules/devel/modules/acc.html#acc.f.acc_db_request'> `int acc_db_request(str "comment", str "dbtable")` </a> 
 
-#### KSR.acc.acc_log_request() ####
+#### KSR.acc.acc_log_request()
+
 <a target='_blank' href='/docs/modules/devel/modules/acc.html#acc.f.acc_log_request'> `int acc_log_request(str "comment")` </a> 
 
-#### KSR.acc.acc_request() ####
+#### KSR.acc.acc_request()
+
 <a target='_blank' href='/docs/modules/devel/modules/acc.html#acc.f.acc_request'> `int acc_request(str "comment", str "dbtable")` </a> 
 
-## alias_db ##
-#### KSR.alias_db.lookup() ####
+## alias_db
+
+#### KSR.alias_db.lookup()
+
 <a target='_blank' href='/docs/modules/devel/modules/alias_db.html#alias_db.f.lookup'> `int lookup(str "stable")` </a> 
 
-#### KSR.alias_db.lookup_ex() ####
+#### KSR.alias_db.lookup_ex()
+
 <a target='_blank' href='/docs/modules/devel/modules/alias_db.html#alias_db.f.lookup_ex'> `int lookup_ex(str "stable", str "sflags")` </a> 
 
-## app_jsdt ##
-#### KSR.app_jsdt.dofile() ####
+## app_jsdt
+
+#### KSR.app_jsdt.dofile()
+
 <a target='_blank' href='/docs/modules/devel/modules/app_jsdt.html#app_jsdt.f.dofile'> `int dofile(str "script")` </a> 
 
-#### KSR.app_jsdt.dostring() ####
+#### KSR.app_jsdt.dostring()
+
 <a target='_blank' href='/docs/modules/devel/modules/app_jsdt.html#app_jsdt.f.dostring'> `int dostring(str "script")` </a> 
 
-#### KSR.app_jsdt.run() ####
+#### KSR.app_jsdt.run()
+
 <a target='_blank' href='/docs/modules/devel/modules/app_jsdt.html#app_jsdt.f.run'> `int run(str "func")` </a> 
 
-#### KSR.app_jsdt.run_p1() ####
+#### KSR.app_jsdt.run_p1()
+
 <a target='_blank' href='/docs/modules/devel/modules/app_jsdt.html#app_jsdt.f.run_p1'> `int run_p1(str "func", str "p1")` </a> 
 
-#### KSR.app_jsdt.run_p2() ####
+#### KSR.app_jsdt.run_p2()
+
 <a target='_blank' href='/docs/modules/devel/modules/app_jsdt.html#app_jsdt.f.run_p2'> `int run_p2(str "func", str "p1", str "p2")` </a> 
 
-#### KSR.app_jsdt.run_p3() ####
+#### KSR.app_jsdt.run_p3()
+
 <a target='_blank' href='/docs/modules/devel/modules/app_jsdt.html#app_jsdt.f.run_p3'> `int run_p3(str "func", str "p1", str "p2", str "p3")` </a> 
 
-#### KSR.app_jsdt.runstring() ####
+#### KSR.app_jsdt.runstring()
+
 <a target='_blank' href='/docs/modules/devel/modules/app_jsdt.html#app_jsdt.f.runstring'> `int runstring(str "script")` </a> 
 
-## app_lua ##
-#### KSR.app_lua.dofile() ####
+## app_lua
+
+#### KSR.app_lua.dofile()
+
 <a target='_blank' href='/docs/modules/devel/modules/app_lua.html#app_lua.f.dofile'> `int dofile(str "script")` </a> 
 
-#### KSR.app_lua.dostring() ####
+#### KSR.app_lua.dostring()
+
 <a target='_blank' href='/docs/modules/devel/modules/app_lua.html#app_lua.f.dostring'> `int dostring(str "script")` </a> 
 
-#### KSR.app_lua.run() ####
+#### KSR.app_lua.run()
+
 <a target='_blank' href='/docs/modules/devel/modules/app_lua.html#app_lua.f.run'> `int run(str "func")` </a> 
 
-#### KSR.app_lua.run_p1() ####
+#### KSR.app_lua.run_p1()
+
 <a target='_blank' href='/docs/modules/devel/modules/app_lua.html#app_lua.f.run_p1'> `int run_p1(str "func", str "p1")` </a> 
 
-#### KSR.app_lua.run_p2() ####
+#### KSR.app_lua.run_p2()
+
 <a target='_blank' href='/docs/modules/devel/modules/app_lua.html#app_lua.f.run_p2'> `int run_p2(str "func", str "p1", str "p2")` </a> 
 
-#### KSR.app_lua.run_p3() ####
+#### KSR.app_lua.run_p3()
+
 <a target='_blank' href='/docs/modules/devel/modules/app_lua.html#app_lua.f.run_p3'> `int run_p3(str "func", str "p1", str "p2", str "p3")` </a> 
 
-#### KSR.app_lua.runstring() ####
+#### KSR.app_lua.runstring()
+
 <a target='_blank' href='/docs/modules/devel/modules/app_lua.html#app_lua.f.runstring'> `int runstring(str "script")` </a> 
 
-## app_python ##
-#### KSR.app_python.exec() ####
+## app_python
+
+#### KSR.app_python.exec()
+
 <a target='_blank' href='/docs/modules/devel/modules/app_python.html#app_python.f.exec'> `int exec(str "method")` </a> 
 
-#### KSR.app_python.exec_p1() ####
+#### KSR.app_python.exec_p1()
+
 <a target='_blank' href='/docs/modules/devel/modules/app_python.html#app_python.f.exec_p1'> `int exec_p1(str "method", str "p1")` </a> 
 
-## app_sqlang ##
-#### KSR.app_sqlang.dofile() ####
+## app_sqlang
+
+#### KSR.app_sqlang.dofile()
+
 <a target='_blank' href='/docs/modules/devel/modules/app_sqlang.html#app_sqlang.f.dofile'> `int dofile(str "script")` </a> 
 
-#### KSR.app_sqlang.dostring() ####
+#### KSR.app_sqlang.dostring()
+
 <a target='_blank' href='/docs/modules/devel/modules/app_sqlang.html#app_sqlang.f.dostring'> `int dostring(str "script")` </a> 
 
-#### KSR.app_sqlang.run() ####
+#### KSR.app_sqlang.run()
+
 <a target='_blank' href='/docs/modules/devel/modules/app_sqlang.html#app_sqlang.f.run'> `int run(str "func")` </a> 
 
-#### KSR.app_sqlang.run_p1() ####
+#### KSR.app_sqlang.run_p1()
+
 <a target='_blank' href='/docs/modules/devel/modules/app_sqlang.html#app_sqlang.f.run_p1'> `int run_p1(str "func", str "p1")` </a> 
 
-#### KSR.app_sqlang.run_p2() ####
+#### KSR.app_sqlang.run_p2()
+
 <a target='_blank' href='/docs/modules/devel/modules/app_sqlang.html#app_sqlang.f.run_p2'> `int run_p2(str "func", str "p1", str "p2")` </a> 
 
-#### KSR.app_sqlang.run_p3() ####
+#### KSR.app_sqlang.run_p3()
+
 <a target='_blank' href='/docs/modules/devel/modules/app_sqlang.html#app_sqlang.f.run_p3'> `int run_p3(str "func", str "p1", str "p2", str "p3")` </a> 
 
-#### KSR.app_sqlang.runstring() ####
+#### KSR.app_sqlang.runstring()
+
 <a target='_blank' href='/docs/modules/devel/modules/app_sqlang.html#app_sqlang.f.runstring'> `int runstring(str "script")` </a> 
 
-## async ##
-#### KSR.async.route() ####
+## async
+
+#### KSR.async.route()
+
 <a target='_blank' href='/docs/modules/devel/modules/async.html#async.f.route'> `int route(str "rn", int s)` </a> 
 
-#### KSR.async.task_route() ####
+#### KSR.async.task_route()
+
 <a target='_blank' href='/docs/modules/devel/modules/async.html#async.f.task_route'> `int task_route(str "rn")` </a> 
 
-## auth ##
-#### KSR.auth.auth_challenge() ####
+## auth
+
+#### KSR.auth.auth_challenge()
+
 <a target='_blank' href='/docs/modules/devel/modules/auth.html#auth.f.auth_challenge'> `int auth_challenge(str "realm", int flags)` </a> 
 
-#### KSR.auth.consume_credentials() ####
+#### KSR.auth.consume_credentials()
+
 <a target='_blank' href='/docs/modules/devel/modules/auth.html#auth.f.consume_credentials'> `int consume_credentials()` </a> 
 
-#### KSR.auth.has_credentials() ####
+#### KSR.auth.has_credentials()
+
 <a target='_blank' href='/docs/modules/devel/modules/auth.html#auth.f.has_credentials'> `int has_credentials(str "srealm")` </a> 
 
-#### KSR.auth.pv_auth_check() ####
+#### KSR.auth.pv_auth_check()
+
 <a target='_blank' href='/docs/modules/devel/modules/auth.html#auth.f.pv_auth_check'> `int pv_auth_check(str "srealm", str "spasswd", int vflags, int vchecks)` </a> 
 
-## auth_db ##
-#### KSR.auth_db.auth_check() ####
+## auth_db
+
+#### KSR.auth_db.auth_check()
+
 <a target='_blank' href='/docs/modules/devel/modules/auth_db.html#auth_db.f.auth_check'> `int auth_check(str "srealm", str "stable", int iflags)` </a> 
 
-#### KSR.auth_db.is_subscriber() ####
+#### KSR.auth_db.is_subscriber()
+
 <a target='_blank' href='/docs/modules/devel/modules/auth_db.html#auth_db.f.is_subscriber'> `int is_subscriber(str "suri", str "stable", int iflags)` </a> 
 
-## auth_xkeys ##
-#### KSR.auth_xkeys.auth_xkeys_add() ####
+## auth_xkeys
+
+#### KSR.auth_xkeys.auth_xkeys_add()
+
 <a target='_blank' href='/docs/modules/devel/modules/auth_xkeys.html#auth_xkeys.f.auth_xkeys_add'> `int auth_xkeys_add(str "shdr", str "skey", str "salg", str "sdata")` </a> 
 
-#### KSR.auth_xkeys.auth_xkeys_check() ####
+#### KSR.auth_xkeys.auth_xkeys_check()
+
 <a target='_blank' href='/docs/modules/devel/modules/auth_xkeys.html#auth_xkeys.f.auth_xkeys_check'> `int auth_xkeys_check(str "shdr", str "skey", str "salg", str "sdata")` </a> 
 
-## call_control ##
-#### KSR.call_control.call_control() ####
+## call_control
+
+#### KSR.call_control.call_control()
+
 <a target='_blank' href='/docs/modules/devel/modules/call_control.html#call_control.f.call_control'> `int call_control()` </a> 
 
-## cfgutils ##
-#### KSR.cfgutils.abort() ####
+## cfgutils
+
+#### KSR.cfgutils.abort()
+
 <a target='_blank' href='/docs/modules/devel/modules/cfgutils.html#cfgutils.f.abort'> `int abort()` </a> 
 
-#### KSR.cfgutils.core_hash() ####
+#### KSR.cfgutils.core_hash()
+
 <a target='_blank' href='/docs/modules/devel/modules/cfgutils.html#cfgutils.f.core_hash'> `int core_hash(str "s1", str "s2", int sz)` </a> 
 
-#### KSR.cfgutils.lock() ####
+#### KSR.cfgutils.lock()
+
 <a target='_blank' href='/docs/modules/devel/modules/cfgutils.html#cfgutils.f.lock'> `int lock(str "lkey")` </a> 
 
-#### KSR.cfgutils.pkg_status() ####
+#### KSR.cfgutils.pkg_status()
+
 <a target='_blank' href='/docs/modules/devel/modules/cfgutils.html#cfgutils.f.pkg_status'> `int pkg_status()` </a> 
 
-#### KSR.cfgutils.pkg_summary() ####
+#### KSR.cfgutils.pkg_summary()
+
 <a target='_blank' href='/docs/modules/devel/modules/cfgutils.html#cfgutils.f.pkg_summary'> `int pkg_summary()` </a> 
 
-#### KSR.cfgutils.rand_event() ####
+#### KSR.cfgutils.rand_event()
+
 <a target='_blank' href='/docs/modules/devel/modules/cfgutils.html#cfgutils.f.rand_event'> `int rand_event()` </a> 
 
-#### KSR.cfgutils.rand_get_prob() ####
+#### KSR.cfgutils.rand_get_prob()
+
 <a target='_blank' href='/docs/modules/devel/modules/cfgutils.html#cfgutils.f.rand_get_prob'> `int rand_get_prob()` </a> 
 
-#### KSR.cfgutils.rand_reset_prob() ####
+#### KSR.cfgutils.rand_reset_prob()
+
 <a target='_blank' href='/docs/modules/devel/modules/cfgutils.html#cfgutils.f.rand_reset_prob'> `int rand_reset_prob()` </a> 
 
-#### KSR.cfgutils.rand_set_prob() ####
+#### KSR.cfgutils.rand_set_prob()
+
 <a target='_blank' href='/docs/modules/devel/modules/cfgutils.html#cfgutils.f.rand_set_prob'> `int rand_set_prob(int percent_par)` </a> 
 
-#### KSR.cfgutils.shm_status() ####
+#### KSR.cfgutils.shm_status()
+
 <a target='_blank' href='/docs/modules/devel/modules/cfgutils.html#cfgutils.f.shm_status'> `int shm_status()` </a> 
 
-#### KSR.cfgutils.shm_summary() ####
+#### KSR.cfgutils.shm_summary()
+
 <a target='_blank' href='/docs/modules/devel/modules/cfgutils.html#cfgutils.f.shm_summary'> `int shm_summary()` </a> 
 
-#### KSR.cfgutils.trylock() ####
+#### KSR.cfgutils.trylock()
+
 <a target='_blank' href='/docs/modules/devel/modules/cfgutils.html#cfgutils.f.trylock'> `int trylock(str "lkey")` </a> 
 
-#### KSR.cfgutils.unlock() ####
+#### KSR.cfgutils.unlock()
+
 <a target='_blank' href='/docs/modules/devel/modules/cfgutils.html#cfgutils.f.unlock'> `int unlock(str "lkey")` </a> 
 
-## corex ##
-#### KSR.corex.append_branch() ####
+## corex
+
+#### KSR.corex.append_branch()
+
 <a target='_blank' href='/docs/modules/devel/modules/corex.html#corex.f.append_branch'> `int append_branch()` </a> 
 
-#### KSR.corex.append_branch_uri() ####
+#### KSR.corex.append_branch_uri()
+
 <a target='_blank' href='/docs/modules/devel/modules/corex.html#corex.f.append_branch_uri'> `int append_branch_uri(str "uri")` </a> 
 
-#### KSR.corex.append_branch_uri_q() ####
+#### KSR.corex.append_branch_uri_q()
+
 <a target='_blank' href='/docs/modules/devel/modules/corex.html#corex.f.append_branch_uri_q'> `int append_branch_uri_q(str "uri", str "q")` </a> 
 
-## debugger ##
-#### KSR.debugger.dbg_pv_dump() ####
+## debugger
+
+#### KSR.debugger.dbg_pv_dump()
+
 <a target='_blank' href='/docs/modules/devel/modules/debugger.html#debugger.f.dbg_pv_dump'> `int dbg_pv_dump()` </a> 
 
-#### KSR.debugger.dbg_pv_dump_ex() ####
+#### KSR.debugger.dbg_pv_dump_ex()
+
 <a target='_blank' href='/docs/modules/devel/modules/debugger.html#debugger.f.dbg_pv_dump_ex'> `int dbg_pv_dump_ex(int mask, int level)` </a> 
 
-## dialog ##
-#### KSR.dialog.dlg_bye() ####
+## dialog
+
+#### KSR.dialog.dlg_bye()
+
 <a target='_blank' href='/docs/modules/devel/modules/dialog.html#dialog.f.dlg_bye'> `int dlg_bye(str "side")` </a> 
 
-#### KSR.dialog.dlg_get() ####
+#### KSR.dialog.dlg_get()
+
 <a target='_blank' href='/docs/modules/devel/modules/dialog.html#dialog.f.dlg_get'> `int dlg_get(str "sc", str "sf", str "st")` </a> 
 
-#### KSR.dialog.dlg_isflagset() ####
+#### KSR.dialog.dlg_isflagset()
+
 <a target='_blank' href='/docs/modules/devel/modules/dialog.html#dialog.f.dlg_isflagset'> `int dlg_isflagset(int val)` </a> 
 
-#### KSR.dialog.dlg_manage() ####
+#### KSR.dialog.dlg_manage()
+
 <a target='_blank' href='/docs/modules/devel/modules/dialog.html#dialog.f.dlg_manage'> `int dlg_manage()` </a> 
 
-#### KSR.dialog.dlg_resetflag() ####
+#### KSR.dialog.dlg_resetflag()
+
 <a target='_blank' href='/docs/modules/devel/modules/dialog.html#dialog.f.dlg_resetflag'> `int dlg_resetflag(int val)` </a> 
 
-#### KSR.dialog.dlg_set_property() ####
+#### KSR.dialog.dlg_set_property()
+
 <a target='_blank' href='/docs/modules/devel/modules/dialog.html#dialog.f.dlg_set_property'> `int dlg_set_property(str "pval")` </a> 
 
-#### KSR.dialog.dlg_set_timeout() ####
+#### KSR.dialog.dlg_set_timeout()
+
 <a target='_blank' href='/docs/modules/devel/modules/dialog.html#dialog.f.dlg_set_timeout'> `int dlg_set_timeout(int to)` </a> 
 
-#### KSR.dialog.dlg_set_timeout_id() ####
+#### KSR.dialog.dlg_set_timeout_id()
+
 <a target='_blank' href='/docs/modules/devel/modules/dialog.html#dialog.f.dlg_set_timeout_id'> `int dlg_set_timeout_id(int to, int he, int hi)` </a> 
 
-#### KSR.dialog.dlg_setflag() ####
+#### KSR.dialog.dlg_setflag()
+
 <a target='_blank' href='/docs/modules/devel/modules/dialog.html#dialog.f.dlg_setflag'> `int dlg_setflag(int val)` </a> 
 
-#### KSR.dialog.get_profile_size() ####
+#### KSR.dialog.get_profile_size()
+
 <a target='_blank' href='/docs/modules/devel/modules/dialog.html#dialog.f.get_profile_size'> `int get_profile_size(str "sprofile", str "svalue", str "spv")` </a> 
 
-#### KSR.dialog.get_profile_size_static() ####
+#### KSR.dialog.get_profile_size_static()
+
 <a target='_blank' href='/docs/modules/devel/modules/dialog.html#dialog.f.get_profile_size_static'> `int get_profile_size_static(str "sprofile", str "spv")` </a> 
 
-#### KSR.dialog.is_in_profile() ####
+#### KSR.dialog.is_in_profile()
+
 <a target='_blank' href='/docs/modules/devel/modules/dialog.html#dialog.f.is_in_profile'> `int is_in_profile(str "sprofile", str "svalue")` </a> 
 
-#### KSR.dialog.is_in_profile_static() ####
+#### KSR.dialog.is_in_profile_static()
+
 <a target='_blank' href='/docs/modules/devel/modules/dialog.html#dialog.f.is_in_profile_static'> `int is_in_profile_static(str "sprofile")` </a> 
 
-#### KSR.dialog.is_known_dlg() ####
+#### KSR.dialog.is_known_dlg()
+
 <a target='_blank' href='/docs/modules/devel/modules/dialog.html#dialog.f.is_known_dlg'> `int is_known_dlg()` </a> 
 
-#### KSR.dialog.set_dlg_profile() ####
+#### KSR.dialog.set_dlg_profile()
+
 <a target='_blank' href='/docs/modules/devel/modules/dialog.html#dialog.f.set_dlg_profile'> `int set_dlg_profile(str "sprofile", str "svalue")` </a> 
 
-#### KSR.dialog.set_dlg_profile_static() ####
+#### KSR.dialog.set_dlg_profile_static()
+
 <a target='_blank' href='/docs/modules/devel/modules/dialog.html#dialog.f.set_dlg_profile_static'> `int set_dlg_profile_static(str "sprofile")` </a> 
 
-#### KSR.dialog.unset_dlg_profile() ####
+#### KSR.dialog.unset_dlg_profile()
+
 <a target='_blank' href='/docs/modules/devel/modules/dialog.html#dialog.f.unset_dlg_profile'> `int unset_dlg_profile(str "sprofile", str "svalue")` </a> 
 
-#### KSR.dialog.unset_dlg_profile_static() ####
+#### KSR.dialog.unset_dlg_profile_static()
+
 <a target='_blank' href='/docs/modules/devel/modules/dialog.html#dialog.f.unset_dlg_profile_static'> `int unset_dlg_profile_static(str "sprofile")` </a> 
 
-## dialplan ##
-#### KSR.dialplan.dp_match() ####
+## dialplan
+
+#### KSR.dialplan.dp_match()
+
 <a target='_blank' href='/docs/modules/devel/modules/dialplan.html#dialplan.f.dp_match'> `int dp_match(int dpid, str "src")` </a> 
 
-#### KSR.dialplan.dp_replace() ####
+#### KSR.dialplan.dp_replace()
+
 <a target='_blank' href='/docs/modules/devel/modules/dialplan.html#dialplan.f.dp_replace'> `int dp_replace(int dpid, str "src", str "dst")` </a> 
 
-## dispatcher ##
-#### KSR.dispatcher.ds_next_domain() ####
+## dispatcher
+
+#### KSR.dispatcher.ds_next_domain()
+
 <a target='_blank' href='/docs/modules/devel/modules/dispatcher.html#dispatcher.f.ds_next_domain'> `int ds_next_domain()` </a> 
 
-#### KSR.dispatcher.ds_next_dst() ####
+#### KSR.dispatcher.ds_next_dst()
+
 <a target='_blank' href='/docs/modules/devel/modules/dispatcher.html#dispatcher.f.ds_next_dst'> `int ds_next_dst()` </a> 
 
-#### KSR.dispatcher.ds_select() ####
+#### KSR.dispatcher.ds_select()
+
 <a target='_blank' href='/docs/modules/devel/modules/dispatcher.html#dispatcher.f.ds_select'> `int ds_select(int set, int alg)` </a> 
 
-#### KSR.dispatcher.ds_select_domain() ####
+#### KSR.dispatcher.ds_select_domain()
+
 <a target='_blank' href='/docs/modules/devel/modules/dispatcher.html#dispatcher.f.ds_select_domain'> `int ds_select_domain(int set, int alg)` </a> 
 
-#### KSR.dispatcher.ds_select_domain_limit() ####
+#### KSR.dispatcher.ds_select_domain_limit()
+
 <a target='_blank' href='/docs/modules/devel/modules/dispatcher.html#dispatcher.f.ds_select_domain_limit'> `int ds_select_domain_limit(int set, int alg, int limit)` </a> 
 
-#### KSR.dispatcher.ds_select_dst() ####
+#### KSR.dispatcher.ds_select_dst()
+
 <a target='_blank' href='/docs/modules/devel/modules/dispatcher.html#dispatcher.f.ds_select_dst'> `int ds_select_dst(int set, int alg)` </a> 
 
-#### KSR.dispatcher.ds_select_dst_limit() ####
+#### KSR.dispatcher.ds_select_dst_limit()
+
 <a target='_blank' href='/docs/modules/devel/modules/dispatcher.html#dispatcher.f.ds_select_dst_limit'> `int ds_select_dst_limit(int set, int alg, int limit)` </a> 
 
-#### KSR.dispatcher.ds_select_limit() ####
+#### KSR.dispatcher.ds_select_limit()
+
 <a target='_blank' href='/docs/modules/devel/modules/dispatcher.html#dispatcher.f.ds_select_limit'> `int ds_select_limit(int set, int alg, int limit)` </a> 
 
-## diversion ##
-#### KSR.diversion.add_diversion() ####
+## diversion
+
+#### KSR.diversion.add_diversion()
+
 <a target='_blank' href='/docs/modules/devel/modules/diversion.html#diversion.f.add_diversion'> `int add_diversion(str "reason")` </a> 
 
-#### KSR.diversion.add_diversion_uri() ####
+#### KSR.diversion.add_diversion_uri()
+
 <a target='_blank' href='/docs/modules/devel/modules/diversion.html#diversion.f.add_diversion_uri'> `int add_diversion_uri(str "reason", str "uri")` </a> 
 
-## domain ##
-#### KSR.domain.is_domain_local() ####
+## domain
+
+#### KSR.domain.is_domain_local()
+
 <a target='_blank' href='/docs/modules/devel/modules/domain.html#domain.f.is_domain_local'> `int is_domain_local(str "sdomain")` </a> 
 
-#### KSR.domain.is_from_local() ####
+#### KSR.domain.is_from_local()
+
 <a target='_blank' href='/docs/modules/devel/modules/domain.html#domain.f.is_from_local'> `int is_from_local()` </a> 
 
-#### KSR.domain.is_uri_host_local() ####
+#### KSR.domain.is_uri_host_local()
+
 <a target='_blank' href='/docs/modules/devel/modules/domain.html#domain.f.is_uri_host_local'> `int is_uri_host_local()` </a> 
 
-#### KSR.domain.lookup_domain() ####
+#### KSR.domain.lookup_domain()
+
 <a target='_blank' href='/docs/modules/devel/modules/domain.html#domain.f.lookup_domain'> `int lookup_domain(str "_sdomain")` </a> 
 
-#### KSR.domain.lookup_domain_prefix() ####
+#### KSR.domain.lookup_domain_prefix()
+
 <a target='_blank' href='/docs/modules/devel/modules/domain.html#domain.f.lookup_domain_prefix'> `int lookup_domain_prefix(str "_sdomain", str "_sprefix")` </a> 
 
-## drouting ##
-#### KSR.drouting.do_routing() ####
+## drouting
+
+#### KSR.drouting.do_routing()
+
 <a target='_blank' href='/docs/modules/devel/modules/drouting.html#drouting.f.do_routing'> `int do_routing(int grp_id)` </a> 
 
-#### KSR.drouting.do_routing_furi() ####
+#### KSR.drouting.do_routing_furi()
+
 <a target='_blank' href='/docs/modules/devel/modules/drouting.html#drouting.f.do_routing_furi'> `int do_routing_furi()` </a> 
 
-#### KSR.drouting.goes_to_gw() ####
+#### KSR.drouting.goes_to_gw()
+
 <a target='_blank' href='/docs/modules/devel/modules/drouting.html#drouting.f.goes_to_gw'> `int goes_to_gw()` </a> 
 
-#### KSR.drouting.goes_to_gw_type() ####
+#### KSR.drouting.goes_to_gw_type()
+
 <a target='_blank' href='/docs/modules/devel/modules/drouting.html#drouting.f.goes_to_gw_type'> `int goes_to_gw_type(int type)` </a> 
 
-#### KSR.drouting.is_from_gw() ####
+#### KSR.drouting.is_from_gw()
+
 <a target='_blank' href='/docs/modules/devel/modules/drouting.html#drouting.f.is_from_gw'> `int is_from_gw()` </a> 
 
-#### KSR.drouting.is_from_gw_type() ####
+#### KSR.drouting.is_from_gw_type()
+
 <a target='_blank' href='/docs/modules/devel/modules/drouting.html#drouting.f.is_from_gw_type'> `int is_from_gw_type(int type)` </a> 
 
-#### KSR.drouting.is_from_gw_type_flags() ####
+#### KSR.drouting.is_from_gw_type_flags()
+
 <a target='_blank' href='/docs/modules/devel/modules/drouting.html#drouting.f.is_from_gw_type_flags'> `int is_from_gw_type_flags(int type, int flags)` </a> 
 
-#### KSR.drouting.next_routing() ####
+#### KSR.drouting.next_routing()
+
 <a target='_blank' href='/docs/modules/devel/modules/drouting.html#drouting.f.next_routing'> `int next_routing()` </a> 
 
-#### KSR.drouting.use_next_gw() ####
+#### KSR.drouting.use_next_gw()
+
 <a target='_blank' href='/docs/modules/devel/modules/drouting.html#drouting.f.use_next_gw'> `int use_next_gw()` </a> 
 
-## enum ##
-#### KSR.enum.enum_i_query_suffix() ####
+## enum
+
+#### KSR.enum.enum_i_query_suffix()
+
 <a target='_blank' href='/docs/modules/devel/modules/enum.html#enum.f.enum_i_query_suffix'> `int enum_i_query_suffix(str "vsuffix")` </a> 
 
-#### KSR.enum.enum_pv_query() ####
+#### KSR.enum.enum_pv_query()
+
 <a target='_blank' href='/docs/modules/devel/modules/enum.html#enum.f.enum_pv_query'> `int enum_pv_query(str "ve164")` </a> 
 
-#### KSR.enum.enum_pv_query_suffix() ####
+#### KSR.enum.enum_pv_query_suffix()
+
 <a target='_blank' href='/docs/modules/devel/modules/enum.html#enum.f.enum_pv_query_suffix'> `int enum_pv_query_suffix(str "ve164", str "vsuffix")` </a> 
 
-#### KSR.enum.enum_pv_query_suffix_service() ####
+#### KSR.enum.enum_pv_query_suffix_service()
+
 <a target='_blank' href='/docs/modules/devel/modules/enum.html#enum.f.enum_pv_query_suffix_service'> `int enum_pv_query_suffix_service(str "ve164", str "vsuffix", str "vservice")` </a> 
 
-#### KSR.enum.enum_query() ####
+#### KSR.enum.enum_query()
+
 <a target='_blank' href='/docs/modules/devel/modules/enum.html#enum.f.enum_query'> `int enum_query()` </a> 
 
-#### KSR.enum.enum_query_suffix() ####
+#### KSR.enum.enum_query_suffix()
+
 <a target='_blank' href='/docs/modules/devel/modules/enum.html#enum.f.enum_query_suffix'> `int enum_query_suffix(str "vsuffix")` </a> 
 
-#### KSR.enum.enum_query_suffix_service() ####
+#### KSR.enum.enum_query_suffix_service()
+
 <a target='_blank' href='/docs/modules/devel/modules/enum.html#enum.f.enum_query_suffix_service'> `int enum_query_suffix_service(str "vsuffix", str "vservice")` </a> 
 
-#### KSR.enum.i_enum_query() ####
+#### KSR.enum.i_enum_query()
+
 <a target='_blank' href='/docs/modules/devel/modules/enum.html#enum.f.i_enum_query'> `int i_enum_query()` </a> 
 
-#### KSR.enum.i_enum_query_suffix_service() ####
+#### KSR.enum.i_enum_query_suffix_service()
+
 <a target='_blank' href='/docs/modules/devel/modules/enum.html#enum.f.i_enum_query_suffix_service'> `int i_enum_query_suffix_service(str "vsuffix", str "vservice")` </a> 
 
-#### KSR.enum.is_from_user_enum() ####
+#### KSR.enum.is_from_user_enum()
+
 <a target='_blank' href='/docs/modules/devel/modules/enum.html#enum.f.is_from_user_enum'> `int is_from_user_enum()` </a> 
 
-#### KSR.enum.is_from_user_enum_suffix() ####
+#### KSR.enum.is_from_user_enum_suffix()
+
 <a target='_blank' href='/docs/modules/devel/modules/enum.html#enum.f.is_from_user_enum_suffix'> `int is_from_user_enum_suffix(str "vsuffix")` </a> 
 
-#### KSR.enum.is_from_user_enum_suffix_service() ####
+#### KSR.enum.is_from_user_enum_suffix_service()
+
 <a target='_blank' href='/docs/modules/devel/modules/enum.html#enum.f.is_from_user_enum_suffix_service'> `int is_from_user_enum_suffix_service(str "vsuffix", str "vservice")` </a> 
 
-## evapi ##
-#### KSR.evapi.close() ####
+## evapi
+
+#### KSR.evapi.close()
+
 <a target='_blank' href='/docs/modules/devel/modules/evapi.html#evapi.f.close'> `int close()` </a> 
 
-#### KSR.evapi.relay() ####
+#### KSR.evapi.relay()
+
 <a target='_blank' href='/docs/modules/devel/modules/evapi.html#evapi.f.relay'> `int relay(str "sdata")` </a> 
 
-#### KSR.evapi.relay_multicast() ####
+#### KSR.evapi.relay_multicast()
+
 <a target='_blank' href='/docs/modules/devel/modules/evapi.html#evapi.f.relay_multicast'> `int relay_multicast(str "sdata", str "stag")` </a> 
 
-#### KSR.evapi.relay_unicast() ####
+#### KSR.evapi.relay_unicast()
+
 <a target='_blank' href='/docs/modules/devel/modules/evapi.html#evapi.f.relay_unicast'> `int relay_unicast(str "sdata", str "stag")` </a> 
 
-#### KSR.evapi.set_tag() ####
+#### KSR.evapi.set_tag()
+
 <a target='_blank' href='/docs/modules/devel/modules/evapi.html#evapi.f.set_tag'> `int set_tag(str "stag")` </a> 
 
-## exec ##
-#### KSR.exec.exec_avp() ####
+## exec
+
+#### KSR.exec.exec_avp()
+
 <a target='_blank' href='/docs/modules/devel/modules/exec.html#exec.f.exec_avp'> `int exec_avp(str "cmd")` </a> 
 
-#### KSR.exec.exec_dset() ####
+#### KSR.exec.exec_dset()
+
 <a target='_blank' href='/docs/modules/devel/modules/exec.html#exec.f.exec_dset'> `int exec_dset(str "cmd")` </a> 
 
-#### KSR.exec.exec_msg() ####
+#### KSR.exec.exec_msg()
+
 <a target='_blank' href='/docs/modules/devel/modules/exec.html#exec.f.exec_msg'> `int exec_msg(str "cmd")` </a> 
 
-## geoip ##
-#### KSR.geoip.match() ####
+## geoip
+
+#### KSR.geoip.match()
+
 <a target='_blank' href='/docs/modules/devel/modules/geoip.html#geoip.f.match'> `int match(str "tomatch", str "pvclass")` </a> 
 
-## geoip2 ##
-#### KSR.geoip2.match() ####
+## geoip2
+
+#### KSR.geoip2.match()
+
 <a target='_blank' href='/docs/modules/devel/modules/geoip2.html#geoip2.f.match'> `int match(str "tomatch", str "pvclass")` </a> 
 
-## htable ##
-#### KSR.htable.sht_iterator_end() ####
+## htable
+
+#### KSR.htable.sht_iterator_end()
+
 <a target='_blank' href='/docs/modules/devel/modules/htable.html#htable.f.sht_iterator_end'> `int sht_iterator_end(str "iname")` </a> 
 
-#### KSR.htable.sht_iterator_next() ####
+#### KSR.htable.sht_iterator_next()
+
 <a target='_blank' href='/docs/modules/devel/modules/htable.html#htable.f.sht_iterator_next'> `int sht_iterator_next(str "iname")` </a> 
 
-#### KSR.htable.sht_iterator_start() ####
+#### KSR.htable.sht_iterator_start()
+
 <a target='_blank' href='/docs/modules/devel/modules/htable.html#htable.f.sht_iterator_start'> `int sht_iterator_start(str "iname", str "hname")` </a> 
 
-#### KSR.htable.sht_lock() ####
+#### KSR.htable.sht_lock()
+
 <a target='_blank' href='/docs/modules/devel/modules/htable.html#htable.f.sht_lock'> `int sht_lock(str "htname", str "skey")` </a> 
 
-#### KSR.htable.sht_reset() ####
+#### KSR.htable.sht_reset()
+
 <a target='_blank' href='/docs/modules/devel/modules/htable.html#htable.f.sht_reset'> `int sht_reset(str "hname")` </a> 
 
-#### KSR.htable.sht_unlock() ####
+#### KSR.htable.sht_unlock()
+
 <a target='_blank' href='/docs/modules/devel/modules/htable.html#htable.f.sht_unlock'> `int sht_unlock(str "htname", str "skey")` </a> 
 
-## imc ##
-#### KSR.imc.imc_manager() ####
+## imc
+
+#### KSR.imc.imc_manager()
+
 <a target='_blank' href='/docs/modules/devel/modules/imc.html#imc.f.imc_manager'> `int imc_manager()` </a> 
 
-## jsonrpcs ##
-#### KSR.jsonrpcs.exec() ####
+## jsonrpcs
+
+#### KSR.jsonrpcs.exec()
+
 <a target='_blank' href='/docs/modules/devel/modules/jsonrpcs.html#jsonrpcs.f.exec'> `int exec(str "scmd")` </a> 
 
-## keepalive ##
-#### KSR.keepalive.is_alive() ####
+## keepalive
+
+#### KSR.keepalive.is_alive()
+
 <a target='_blank' href='/docs/modules/devel/modules/keepalive.html#keepalive.f.is_alive'> `int is_alive(str "dest")` </a> 
 
-## kex ##
-#### KSR.kex.resetdebug() ####
+## kex
+
+#### KSR.kex.resetdebug()
+
 <a target='_blank' href='/docs/modules/devel/modules/kex.html#kex.f.resetdebug'> `int resetdebug()` </a> 
 
-#### KSR.kex.setdebug() ####
+#### KSR.kex.setdebug()
+
 <a target='_blank' href='/docs/modules/devel/modules/kex.html#kex.f.setdebug'> `int setdebug(int lval)` </a> 
 
-## lcr ##
-#### KSR.lcr.defunct_gw() ####
+## lcr
+
+#### KSR.lcr.defunct_gw()
+
 <a target='_blank' href='/docs/modules/devel/modules/lcr.html#lcr.f.defunct_gw'> `int defunct_gw(int defunct_period)` </a> 
 
-#### KSR.lcr.from_any_gw() ####
+#### KSR.lcr.from_any_gw()
+
 <a target='_blank' href='/docs/modules/devel/modules/lcr.html#lcr.f.from_any_gw'> `int from_any_gw()` </a> 
 
-#### KSR.lcr.from_any_gw_addr() ####
+#### KSR.lcr.from_any_gw_addr()
+
 <a target='_blank' href='/docs/modules/devel/modules/lcr.html#lcr.f.from_any_gw_addr'> `int from_any_gw_addr(str "addr_str", int transport)` </a> 
 
-#### KSR.lcr.from_gw() ####
+#### KSR.lcr.from_gw()
+
 <a target='_blank' href='/docs/modules/devel/modules/lcr.html#lcr.f.from_gw'> `int from_gw(int lcr_id)` </a> 
 
-#### KSR.lcr.from_gw_addr() ####
+#### KSR.lcr.from_gw_addr()
+
 <a target='_blank' href='/docs/modules/devel/modules/lcr.html#lcr.f.from_gw_addr'> `int from_gw_addr(int lcr_id, str "addr_str", int transport)` </a> 
 
-#### KSR.lcr.inactivate_gw() ####
+#### KSR.lcr.inactivate_gw()
+
 <a target='_blank' href='/docs/modules/devel/modules/lcr.html#lcr.f.inactivate_gw'> `int inactivate_gw()` </a> 
 
-#### KSR.lcr.load_gws() ####
+#### KSR.lcr.load_gws()
+
 <a target='_blank' href='/docs/modules/devel/modules/lcr.html#lcr.f.load_gws'> `int load_gws(int lcr_id)` </a> 
 
-#### KSR.lcr.load_gws_furi() ####
+#### KSR.lcr.load_gws_furi()
+
 <a target='_blank' href='/docs/modules/devel/modules/lcr.html#lcr.f.load_gws_furi'> `int load_gws_furi(int lcr_id, str "ruri_user", str "from_uri")` </a> 
 
-#### KSR.lcr.load_gws_ruser() ####
+#### KSR.lcr.load_gws_ruser()
+
 <a target='_blank' href='/docs/modules/devel/modules/lcr.html#lcr.f.load_gws_ruser'> `int load_gws_ruser(int lcr_id, str "ruri_user")` </a> 
 
-#### KSR.lcr.next_gw() ####
+#### KSR.lcr.next_gw()
+
 <a target='_blank' href='/docs/modules/devel/modules/lcr.html#lcr.f.next_gw'> `int next_gw()` </a> 
 
-#### KSR.lcr.to_any_gw() ####
+#### KSR.lcr.to_any_gw()
+
 <a target='_blank' href='/docs/modules/devel/modules/lcr.html#lcr.f.to_any_gw'> `int to_any_gw()` </a> 
 
-#### KSR.lcr.to_any_gw_addr() ####
+#### KSR.lcr.to_any_gw_addr()
+
 <a target='_blank' href='/docs/modules/devel/modules/lcr.html#lcr.f.to_any_gw_addr'> `int to_any_gw_addr(str "addr_str", int transport)` </a> 
 
-#### KSR.lcr.to_gw() ####
+#### KSR.lcr.to_gw()
+
 <a target='_blank' href='/docs/modules/devel/modules/lcr.html#lcr.f.to_gw'> `int to_gw(int lcr_id)` </a> 
 
-#### KSR.lcr.to_gw_addr() ####
+#### KSR.lcr.to_gw_addr()
+
 <a target='_blank' href='/docs/modules/devel/modules/lcr.html#lcr.f.to_gw_addr'> `int to_gw_addr(int lcr_id, str "addr_str", int transport)` </a> 
 
-## log_custom ##
-#### KSR.log_custom.log_udp() ####
+## log_custom
+
+#### KSR.log_custom.log_udp()
+
 <a target='_blank' href='/docs/modules/devel/modules/log_custom.html#log_custom.f.log_udp'> `int log_udp(str "txt")` </a> 
 
-## maxfwd ##
-#### KSR.maxfwd.process_maxfwd() ####
+## maxfwd
+
+#### KSR.maxfwd.process_maxfwd()
+
 <a target='_blank' href='/docs/modules/devel/modules/maxfwd.html#maxfwd.f.process_maxfwd'> `int process_maxfwd(int limit)` </a> 
 
-## mqueue ##
-#### KSR.mqueue.mq_add() ####
+## mqueue
+
+#### KSR.mqueue.mq_add()
+
 <a target='_blank' href='/docs/modules/devel/modules/mqueue.html#mqueue.f.mq_add'> `int mq_add(str "mq", str "key", str "val")` </a> 
 
-#### KSR.mqueue.mq_fetch() ####
+#### KSR.mqueue.mq_fetch()
+
 <a target='_blank' href='/docs/modules/devel/modules/mqueue.html#mqueue.f.mq_fetch'> `int mq_fetch(str "mq")` </a> 
 
-#### KSR.mqueue.mq_pv_free() ####
+#### KSR.mqueue.mq_pv_free()
+
 <a target='_blank' href='/docs/modules/devel/modules/mqueue.html#mqueue.f.mq_pv_free'> `int mq_pv_free(str "mq")` </a> 
 
-#### KSR.mqueue.mq_size() ####
+#### KSR.mqueue.mq_size()
+
 <a target='_blank' href='/docs/modules/devel/modules/mqueue.html#mqueue.f.mq_size'> `int mq_size(str "mq")` </a> 
 
-## msrp ##
-#### KSR.msrp.cmap_lookup() ####
+## msrp
+
+#### KSR.msrp.cmap_lookup()
+
 <a target='_blank' href='/docs/modules/devel/modules/msrp.html#msrp.f.cmap_lookup'> `int cmap_lookup()` </a> 
 
-#### KSR.msrp.cmap_save() ####
+#### KSR.msrp.cmap_save()
+
 <a target='_blank' href='/docs/modules/devel/modules/msrp.html#msrp.f.cmap_save'> `int cmap_save()` </a> 
 
-#### KSR.msrp.is_reply() ####
+#### KSR.msrp.is_reply()
+
 <a target='_blank' href='/docs/modules/devel/modules/msrp.html#msrp.f.is_reply'> `int is_reply()` </a> 
 
-#### KSR.msrp.is_request() ####
+#### KSR.msrp.is_request()
+
 <a target='_blank' href='/docs/modules/devel/modules/msrp.html#msrp.f.is_request'> `int is_request()` </a> 
 
-#### KSR.msrp.relay() ####
+#### KSR.msrp.relay()
+
 <a target='_blank' href='/docs/modules/devel/modules/msrp.html#msrp.f.relay'> `int relay()` </a> 
 
-#### KSR.msrp.relay_flags() ####
+#### KSR.msrp.relay_flags()
+
 <a target='_blank' href='/docs/modules/devel/modules/msrp.html#msrp.f.relay_flags'> `int relay_flags(int rtflags)` </a> 
 
-#### KSR.msrp.reply() ####
+#### KSR.msrp.reply()
+
 <a target='_blank' href='/docs/modules/devel/modules/msrp.html#msrp.f.reply'> `int reply(str "rcode", str "rtext", str "rhdrs")` </a> 
 
-#### KSR.msrp.reply_flags() ####
+#### KSR.msrp.reply_flags()
+
 <a target='_blank' href='/docs/modules/devel/modules/msrp.html#msrp.f.reply_flags'> `int reply_flags(int rtflags)` </a> 
 
-#### KSR.msrp.set_dst() ####
+#### KSR.msrp.set_dst()
+
 <a target='_blank' href='/docs/modules/devel/modules/msrp.html#msrp.f.set_dst'> `int set_dst(str "rtaddr", str "rfsock")` </a> 
 
-## mtree ##
-#### KSR.mtree.mt_match() ####
+## mtree
+
+#### KSR.mtree.mt_match()
+
 <a target='_blank' href='/docs/modules/devel/modules/mtree.html#mtree.f.mt_match'> `int mt_match(str "tname", str "tomatch", int mval)` </a> 
 
-## nathelper ##
-#### KSR.nathelper.add_contact_alias() ####
+## nathelper
+
+#### KSR.nathelper.add_contact_alias()
+
 <a target='_blank' href='/docs/modules/devel/modules/nathelper.html#nathelper.f.add_contact_alias'> `int add_contact_alias()` </a> 
 
-#### KSR.nathelper.add_contact_alias_addr() ####
+#### KSR.nathelper.add_contact_alias_addr()
+
 <a target='_blank' href='/docs/modules/devel/modules/nathelper.html#nathelper.f.add_contact_alias_addr'> `int add_contact_alias_addr(str "ip_str", str "port_str", str "proto_str")` </a> 
 
-#### KSR.nathelper.add_rcv_param() ####
+#### KSR.nathelper.add_rcv_param()
+
 <a target='_blank' href='/docs/modules/devel/modules/nathelper.html#nathelper.f.add_rcv_param'> `int add_rcv_param(int hdr_param)` </a> 
 
-#### KSR.nathelper.fix_nated_contact() ####
+#### KSR.nathelper.fix_nated_contact()
+
 <a target='_blank' href='/docs/modules/devel/modules/nathelper.html#nathelper.f.fix_nated_contact'> `int fix_nated_contact()` </a> 
 
-#### KSR.nathelper.fix_nated_register() ####
+#### KSR.nathelper.fix_nated_register()
+
 <a target='_blank' href='/docs/modules/devel/modules/nathelper.html#nathelper.f.fix_nated_register'> `int fix_nated_register()` </a> 
 
-#### KSR.nathelper.handle_ruri_alias() ####
+#### KSR.nathelper.handle_ruri_alias()
+
 <a target='_blank' href='/docs/modules/devel/modules/nathelper.html#nathelper.f.handle_ruri_alias'> `int handle_ruri_alias()` </a> 
 
-#### KSR.nathelper.is_rfc1918() ####
+#### KSR.nathelper.is_rfc1918()
+
 <a target='_blank' href='/docs/modules/devel/modules/nathelper.html#nathelper.f.is_rfc1918'> `int is_rfc1918(str "address")` </a> 
 
-#### KSR.nathelper.nat_uac_test() ####
+#### KSR.nathelper.nat_uac_test()
+
 <a target='_blank' href='/docs/modules/devel/modules/nathelper.html#nathelper.f.nat_uac_test'> `int nat_uac_test(int tests)` </a> 
 
-#### KSR.nathelper.set_contact_alias() ####
+#### KSR.nathelper.set_contact_alias()
+
 <a target='_blank' href='/docs/modules/devel/modules/nathelper.html#nathelper.f.set_contact_alias'> `int set_contact_alias()` </a> 
 
-## ndb_redis ##
-#### KSR.ndb_redis.redis_cmd() ####
+## ndb_redis
+
+#### KSR.ndb_redis.redis_cmd()
+
 <a target='_blank' href='/docs/modules/devel/modules/ndb_redis.html#ndb_redis.f.redis_cmd'> `int redis_cmd(str "srv", str "rcmd", str "sres")` </a> 
 
-#### KSR.ndb_redis.redis_cmd_p1() ####
+#### KSR.ndb_redis.redis_cmd_p1()
+
 <a target='_blank' href='/docs/modules/devel/modules/ndb_redis.html#ndb_redis.f.redis_cmd_p1'> `int redis_cmd_p1(str "srv", str "rcmd", str "p1", str "sres")` </a> 
 
-#### KSR.ndb_redis.redis_cmd_p2() ####
+#### KSR.ndb_redis.redis_cmd_p2()
+
 <a target='_blank' href='/docs/modules/devel/modules/ndb_redis.html#ndb_redis.f.redis_cmd_p2'> `int redis_cmd_p2(str "srv", str "rcmd", str "p1", str "p2", str "sres")` </a> 
 
-#### KSR.ndb_redis.redis_cmd_p3() ####
+#### KSR.ndb_redis.redis_cmd_p3()
+
 <a target='_blank' href='/docs/modules/devel/modules/ndb_redis.html#ndb_redis.f.redis_cmd_p3'> `int redis_cmd_p3(str "srv", str "rcmd", str "p1", str "p2", str "p3", str "sres")` </a> 
 
-#### KSR.ndb_redis.redis_free() ####
+#### KSR.ndb_redis.redis_free()
+
 <a target='_blank' href='/docs/modules/devel/modules/ndb_redis.html#ndb_redis.f.redis_free'> `int redis_free(str "name")` </a> 
 
-## path ##
-#### KSR.path.add_path() ####
+## path
+
+#### KSR.path.add_path()
+
 <a target='_blank' href='/docs/modules/devel/modules/path.html#path.f.add_path'> `int add_path()` </a> 
 
-#### KSR.path.add_path_received() ####
+#### KSR.path.add_path_received()
+
 <a target='_blank' href='/docs/modules/devel/modules/path.html#path.f.add_path_received'> `int add_path_received()` </a> 
 
-#### KSR.path.add_path_received_user() ####
+#### KSR.path.add_path_received_user()
+
 <a target='_blank' href='/docs/modules/devel/modules/path.html#path.f.add_path_received_user'> `int add_path_received_user(str "_user")` </a> 
 
-#### KSR.path.add_path_received_user_params() ####
+#### KSR.path.add_path_received_user_params()
+
 <a target='_blank' href='/docs/modules/devel/modules/path.html#path.f.add_path_received_user_params'> `int add_path_received_user_params(str "_user", str "_params")` </a> 
 
-#### KSR.path.add_path_user() ####
+#### KSR.path.add_path_user()
+
 <a target='_blank' href='/docs/modules/devel/modules/path.html#path.f.add_path_user'> `int add_path_user(str "_user")` </a> 
 
-#### KSR.path.add_path_user_params() ####
+#### KSR.path.add_path_user_params()
+
 <a target='_blank' href='/docs/modules/devel/modules/path.html#path.f.add_path_user_params'> `int add_path_user_params(str "_user", str "_params")` </a> 
 
-## pdt ##
-#### KSR.pdt.pd_translate() ####
+## pdt
+
+#### KSR.pdt.pd_translate()
+
 <a target='_blank' href='/docs/modules/devel/modules/pdt.html#pdt.f.pd_translate'> `int pd_translate(str "sd", int md)` </a> 
 
-#### KSR.pdt.pprefix2domain() ####
+#### KSR.pdt.pprefix2domain()
+
 <a target='_blank' href='/docs/modules/devel/modules/pdt.html#pdt.f.pprefix2domain'> `int pprefix2domain(int m, int s)` </a> 
 
-## permissions ##
-#### KSR.permissions.allow_address() ####
+## permissions
+
+#### KSR.permissions.allow_address()
+
 <a target='_blank' href='/docs/modules/devel/modules/permissions.html#permissions.f.allow_address'> `int allow_address(int addr_group, str "ips", int port)` </a> 
 
-#### KSR.permissions.allow_source_address() ####
+#### KSR.permissions.allow_source_address()
+
 <a target='_blank' href='/docs/modules/devel/modules/permissions.html#permissions.f.allow_source_address'> `int allow_source_address(int addr_group)` </a> 
 
-## phonenum ##
-#### KSR.phonenum.match() ####
+## phonenum
+
+#### KSR.phonenum.match()
+
 <a target='_blank' href='/docs/modules/devel/modules/phonenum.html#phonenum.f.match'> `int match(str "tomatch", str "pvclass")` </a> 
 
-## pike ##
-#### KSR.pike.pike_check_req() ####
+## pike
+
+#### KSR.pike.pike_check_req()
+
 <a target='_blank' href='/docs/modules/devel/modules/pike.html#pike.f.pike_check_req'> `int pike_check_req()` </a> 
 
-## pipelimit ##
-#### KSR.pipelimit.pl_check() ####
+## pipelimit
+
+#### KSR.pipelimit.pl_check()
+
 <a target='_blank' href='/docs/modules/devel/modules/pipelimit.html#pipelimit.f.pl_check'> `int pl_check(str "pipeid")` </a> 
 
-#### KSR.pipelimit.pl_check_limit() ####
+#### KSR.pipelimit.pl_check_limit()
+
 <a target='_blank' href='/docs/modules/devel/modules/pipelimit.html#pipelimit.f.pl_check_limit'> `int pl_check_limit(str "pipeid", str "alg", int limit)` </a> 
 
-#### KSR.pipelimit.pl_drop() ####
+#### KSR.pipelimit.pl_drop()
+
 <a target='_blank' href='/docs/modules/devel/modules/pipelimit.html#pipelimit.f.pl_drop'> `int pl_drop()` </a> 
 
-#### KSR.pipelimit.pl_drop_range() ####
+#### KSR.pipelimit.pl_drop_range()
+
 <a target='_blank' href='/docs/modules/devel/modules/pipelimit.html#pipelimit.f.pl_drop_range'> `int pl_drop_range(int rmin, int rmax)` </a> 
 
-#### KSR.pipelimit.pl_drop_retry() ####
+#### KSR.pipelimit.pl_drop_retry()
+
 <a target='_blank' href='/docs/modules/devel/modules/pipelimit.html#pipelimit.f.pl_drop_retry'> `int pl_drop_retry(int rafter)` </a> 
 
-## prefix_route ##
-#### KSR.prefix_route.prefix_route() ####
+## prefix_route
+
+#### KSR.prefix_route.prefix_route()
+
 <a target='_blank' href='/docs/modules/devel/modules/prefix_route.html#prefix_route.f.prefix_route'> `int prefix_route(str "ruser")` </a> 
 
-#### KSR.prefix_route.prefix_route_uri() ####
+#### KSR.prefix_route.prefix_route_uri()
+
 <a target='_blank' href='/docs/modules/devel/modules/prefix_route.html#prefix_route.f.prefix_route_uri'> `int prefix_route_uri()` </a> 
 
-## presence ##
-#### KSR.presence.handle_publish() ####
+## presence
+
+#### KSR.presence.handle_publish()
+
 <a target='_blank' href='/docs/modules/devel/modules/presence.html#presence.f.handle_publish'> `int handle_publish()` </a> 
 
-#### KSR.presence.handle_publish_uri() ####
+#### KSR.presence.handle_publish_uri()
+
 <a target='_blank' href='/docs/modules/devel/modules/presence.html#presence.f.handle_publish_uri'> `int handle_publish_uri(str "sender_uri")` </a> 
 
-#### KSR.presence.handle_subscribe() ####
+#### KSR.presence.handle_subscribe()
+
 <a target='_blank' href='/docs/modules/devel/modules/presence.html#presence.f.handle_subscribe'> `int handle_subscribe()` </a> 
 
-#### KSR.presence.handle_subscribe_uri() ####
+#### KSR.presence.handle_subscribe_uri()
+
 <a target='_blank' href='/docs/modules/devel/modules/presence.html#presence.f.handle_subscribe_uri'> `int handle_subscribe_uri(str "wuri")` </a> 
 
-#### KSR.presence.pres_auth_status() ####
+#### KSR.presence.pres_auth_status()
+
 <a target='_blank' href='/docs/modules/devel/modules/presence.html#presence.f.pres_auth_status'> `int pres_auth_status(str "watcher_uri", str "presentity_uri")` </a> 
 
-#### KSR.presence.pres_has_subscribers() ####
+#### KSR.presence.pres_has_subscribers()
+
 <a target='_blank' href='/docs/modules/devel/modules/presence.html#presence.f.pres_has_subscribers'> `int pres_has_subscribers(str "pres_uri", str "wevent")` </a> 
 
-#### KSR.presence.pres_refresh_watchers() ####
+#### KSR.presence.pres_refresh_watchers()
+
 <a target='_blank' href='/docs/modules/devel/modules/presence.html#presence.f.pres_refresh_watchers'> `int pres_refresh_watchers(str "pres", str "event", int type)` </a> 
 
-#### KSR.presence.pres_refresh_watchers_file() ####
+#### KSR.presence.pres_refresh_watchers_file()
+
 <a target='_blank' href='/docs/modules/devel/modules/presence.html#presence.f.pres_refresh_watchers_file'> `int pres_refresh_watchers_file(str "pres", str "event", int type, str "file_uri", str "filename")` </a> 
 
-#### KSR.presence.pres_update_watchers() ####
+#### KSR.presence.pres_update_watchers()
+
 <a target='_blank' href='/docs/modules/devel/modules/presence.html#presence.f.pres_update_watchers'> `int pres_update_watchers(str "pres_uri", str "event")` </a> 
 
-## presence_xml ##
-#### KSR.presence_xml.pres_check_activities() ####
+## presence_xml
+
+#### KSR.presence_xml.pres_check_activities()
+
 <a target='_blank' href='/docs/modules/devel/modules/presence_xml.html#presence_xml.f.pres_check_activities'> `int pres_check_activities(str "pres_uri", str "activity")` </a> 
 
-#### KSR.presence_xml.pres_check_basic() ####
+#### KSR.presence_xml.pres_check_basic()
+
 <a target='_blank' href='/docs/modules/devel/modules/presence_xml.html#presence_xml.f.pres_check_basic'> `int pres_check_basic(str "pres_uri", str "status")` </a> 
 
-## pua ##
-#### KSR.pua.pua_set_publish() ####
+## pua
+
+#### KSR.pua.pua_set_publish()
+
 <a target='_blank' href='/docs/modules/devel/modules/pua.html#pua.f.pua_set_publish'> `int pua_set_publish()` </a> 
 
-#### KSR.pua.pua_update_contact() ####
+#### KSR.pua.pua_update_contact()
+
 <a target='_blank' href='/docs/modules/devel/modules/pua.html#pua.f.pua_update_contact'> `int pua_update_contact()` </a> 
 
-## pvx ##
-#### KSR.pvx.evalx() ####
+## pvx
+
+#### KSR.pvx.evalx()
+
 <a target='_blank' href='/docs/modules/devel/modules/pvx.html#pvx.f.evalx'> `int evalx(str "dst", str "fmt")` </a> 
 
-#### KSR.pvx.pv_var_to_xavp() ####
+#### KSR.pvx.pv_var_to_xavp()
+
 <a target='_blank' href='/docs/modules/devel/modules/pvx.html#pvx.f.pv_var_to_xavp'> `int pv_var_to_xavp(str "varname", str "xname")` </a> 
 
-#### KSR.pvx.pv_xavp_print() ####
+#### KSR.pvx.pv_xavp_print()
+
 <a target='_blank' href='/docs/modules/devel/modules/pvx.html#pvx.f.pv_xavp_print'> `int pv_xavp_print()` </a> 
 
-#### KSR.pvx.pv_xavp_to_var() ####
+#### KSR.pvx.pv_xavp_to_var()
+
 <a target='_blank' href='/docs/modules/devel/modules/pvx.html#pvx.f.pv_xavp_to_var'> `int pv_xavp_to_var(str "xname")` </a> 
 
-#### KSR.pvx.sbranch_append() ####
+#### KSR.pvx.sbranch_append()
+
 <a target='_blank' href='/docs/modules/devel/modules/pvx.html#pvx.f.sbranch_append'> `int sbranch_append()` </a> 
 
-#### KSR.pvx.sbranch_reset() ####
+#### KSR.pvx.sbranch_reset()
+
 <a target='_blank' href='/docs/modules/devel/modules/pvx.html#pvx.f.sbranch_reset'> `int sbranch_reset()` </a> 
 
-#### KSR.pvx.sbranch_set_ruri() ####
+#### KSR.pvx.sbranch_set_ruri()
+
 <a target='_blank' href='/docs/modules/devel/modules/pvx.html#pvx.f.sbranch_set_ruri'> `int sbranch_set_ruri()` </a> 
 
-#### KSR.pvx.xavp_params_explode() ####
+#### KSR.pvx.xavp_params_explode()
+
 <a target='_blank' href='/docs/modules/devel/modules/pvx.html#pvx.f.xavp_params_explode'> `int xavp_params_explode(str "sparams", str "sxname")` </a> 
 
-## regex ##
-#### KSR.regex.pcre_match() ####
+## regex
+
+#### KSR.regex.pcre_match()
+
 <a target='_blank' href='/docs/modules/devel/modules/regex.html#regex.f.pcre_match'> `int pcre_match(str "string", str "regex")` </a> 
 
-#### KSR.regex.pcre_match_group() ####
+#### KSR.regex.pcre_match_group()
+
 <a target='_blank' href='/docs/modules/devel/modules/regex.html#regex.f.pcre_match_group'> `int pcre_match_group(str "string", int num_pcre)` </a> 
 
-## registrar ##
-#### KSR.registrar.add_sock_hdr() ####
+## registrar
+
+#### KSR.registrar.add_sock_hdr()
+
 <a target='_blank' href='/docs/modules/devel/modules/registrar.html#registrar.f.add_sock_hdr'> `int add_sock_hdr(str "hdr_name")` </a> 
 
-#### KSR.registrar.lookup() ####
+#### KSR.registrar.lookup()
+
 <a target='_blank' href='/docs/modules/devel/modules/registrar.html#registrar.f.lookup'> `int lookup(str "table")` </a> 
 
-#### KSR.registrar.lookup_branches() ####
+#### KSR.registrar.lookup_branches()
+
 <a target='_blank' href='/docs/modules/devel/modules/registrar.html#registrar.f.lookup_branches'> `int lookup_branches(str "_dtable")` </a> 
 
-#### KSR.registrar.lookup_to_dset() ####
+#### KSR.registrar.lookup_to_dset()
+
 <a target='_blank' href='/docs/modules/devel/modules/registrar.html#registrar.f.lookup_to_dset'> `int lookup_to_dset(str "table", str "uri")` </a> 
 
-#### KSR.registrar.lookup_uri() ####
+#### KSR.registrar.lookup_uri()
+
 <a target='_blank' href='/docs/modules/devel/modules/registrar.html#registrar.f.lookup_uri'> `int lookup_uri(str "table", str "")` </a> 
 
-#### KSR.registrar.reg_fetch_contacts() ####
+#### KSR.registrar.reg_fetch_contacts()
+
 <a target='_blank' href='/docs/modules/devel/modules/registrar.html#registrar.f.reg_fetch_contacts'> `int reg_fetch_contacts(str "dtable", str "uri", str "profile")` </a> 
 
-#### KSR.registrar.reg_free_contacts() ####
+#### KSR.registrar.reg_free_contacts()
+
 <a target='_blank' href='/docs/modules/devel/modules/registrar.html#registrar.f.reg_free_contacts'> `int reg_free_contacts(str "profile")` </a> 
 
-#### KSR.registrar.registered() ####
+#### KSR.registrar.registered()
+
 <a target='_blank' href='/docs/modules/devel/modules/registrar.html#registrar.f.registered'> `int registered(str "table")` </a> 
 
-#### KSR.registrar.registered_action() ####
+#### KSR.registrar.registered_action()
+
 <a target='_blank' href='/docs/modules/devel/modules/registrar.html#registrar.f.registered_action'> `int registered_action(str "_dtable", str "_uri", int _f, int _aflags)` </a> 
 
-#### KSR.registrar.registered_flags() ####
+#### KSR.registrar.registered_flags()
+
 <a target='_blank' href='/docs/modules/devel/modules/registrar.html#registrar.f.registered_flags'> `int registered_flags(str "_dtable", str "_uri", int _f)` </a> 
 
-#### KSR.registrar.registered_uri() ####
+#### KSR.registrar.registered_uri()
+
 <a target='_blank' href='/docs/modules/devel/modules/registrar.html#registrar.f.registered_uri'> `int registered_uri(str "_dtable", str "_uri")` </a> 
 
-#### KSR.registrar.save() ####
+#### KSR.registrar.save()
+
 <a target='_blank' href='/docs/modules/devel/modules/registrar.html#registrar.f.save'> `int save(str "table", int flags)` </a> 
 
-#### KSR.registrar.save_uri() ####
+#### KSR.registrar.save_uri()
+
 <a target='_blank' href='/docs/modules/devel/modules/registrar.html#registrar.f.save_uri'> `int save_uri(str "table", int flags, str "uri")` </a> 
 
-#### KSR.registrar.set_q_override() ####
+#### KSR.registrar.set_q_override()
+
 <a target='_blank' href='/docs/modules/devel/modules/registrar.html#registrar.f.set_q_override'> `int set_q_override(str "new_q")` </a> 
 
-#### KSR.registrar.unregister() ####
+#### KSR.registrar.unregister()
+
 <a target='_blank' href='/docs/modules/devel/modules/registrar.html#registrar.f.unregister'> `int unregister(str "_dtable", str "_uri")` </a> 
 
-#### KSR.registrar.unregister_ruid() ####
+#### KSR.registrar.unregister_ruid()
+
 <a target='_blank' href='/docs/modules/devel/modules/registrar.html#registrar.f.unregister_ruid'> `int unregister_ruid(str "_dtable", str "_uri", str "_ruid")` </a> 
 
-## rr ##
-#### KSR.rr.add_rr_param() ####
+## rr
+
+#### KSR.rr.add_rr_param()
+
 <a target='_blank' href='/docs/modules/devel/modules/rr.html#rr.f.add_rr_param'> `int add_rr_param(str "sparam")` </a> 
 
-#### KSR.rr.check_route_param() ####
+#### KSR.rr.check_route_param()
+
 <a target='_blank' href='/docs/modules/devel/modules/rr.html#rr.f.check_route_param'> `int check_route_param(str "sre")` </a> 
 
-#### KSR.rr.loose_route() ####
+#### KSR.rr.loose_route()
+
 <a target='_blank' href='/docs/modules/devel/modules/rr.html#rr.f.loose_route'> `int loose_route()` </a> 
 
-#### KSR.rr.record_route() ####
+#### KSR.rr.record_route()
+
 <a target='_blank' href='/docs/modules/devel/modules/rr.html#rr.f.record_route'> `int record_route()` </a> 
 
-#### KSR.rr.record_route_params() ####
+#### KSR.rr.record_route_params()
+
 <a target='_blank' href='/docs/modules/devel/modules/rr.html#rr.f.record_route_params'> `int record_route_params(str "params")` </a> 
 
-#### KSR.rr.remove_record_route() ####
+#### KSR.rr.remove_record_route()
+
 <a target='_blank' href='/docs/modules/devel/modules/rr.html#rr.f.remove_record_route'> `int remove_record_route()` </a> 
 
-## rtjson ##
-#### KSR.rtjson.init_routes() ####
+## rtjson
+
+#### KSR.rtjson.init_routes()
+
 <a target='_blank' href='/docs/modules/devel/modules/rtjson.html#rtjson.f.init_routes'> `int init_routes(str "rdoc")` </a> 
 
-#### KSR.rtjson.next_route() ####
+#### KSR.rtjson.next_route()
+
 <a target='_blank' href='/docs/modules/devel/modules/rtjson.html#rtjson.f.next_route'> `int next_route()` </a> 
 
-#### KSR.rtjson.push_routes() ####
+#### KSR.rtjson.push_routes()
+
 <a target='_blank' href='/docs/modules/devel/modules/rtjson.html#rtjson.f.push_routes'> `int push_routes()` </a> 
 
-#### KSR.rtjson.update_branch() ####
+#### KSR.rtjson.update_branch()
+
 <a target='_blank' href='/docs/modules/devel/modules/rtjson.html#rtjson.f.update_branch'> `int update_branch()` </a> 
 
-## rtpengine ##
-#### KSR.rtpengine.rtpengine_answer() ####
+## rtpengine
+
+This module enables media streams to be proxied via an RTPproxy.
+
+#### KSR.rtpengine.rtpengine_answer()
+
 <a target='_blank' href='/docs/modules/devel/modules/rtpengine.html#rtpengine.f.rtpengine_answer'> `int rtpengine_answer(str "flags")` </a> 
 
-#### KSR.rtpengine.rtpengine_answer0() ####
+#### KSR.rtpengine.rtpengine_answer0()
+
 <a target='_blank' href='/docs/modules/devel/modules/rtpengine.html#rtpengine.f.rtpengine_answer0'> `int rtpengine_answer0()` </a> 
 
-#### KSR.rtpengine.rtpengine_delete() ####
+#### KSR.rtpengine.rtpengine_delete()
+
 <a target='_blank' href='/docs/modules/devel/modules/rtpengine.html#rtpengine.f.rtpengine_delete'> `int rtpengine_delete(str "flags")` </a> 
 
-#### KSR.rtpengine.rtpengine_delete0() ####
+#### KSR.rtpengine.rtpengine_delete0()
+
 <a target='_blank' href='/docs/modules/devel/modules/rtpengine.html#rtpengine.f.rtpengine_delete0'> `int rtpengine_delete0()` </a> 
 
-#### KSR.rtpengine.rtpengine_manage() ####
+#### KSR.rtpengine.rtpengine_manage()
+
 <a target='_blank' href='/docs/modules/devel/modules/rtpengine.html#rtpengine.f.rtpengine_manage'> `int rtpengine_manage(str "flags")` </a> 
 
-#### KSR.rtpengine.rtpengine_manage0() ####
+#### KSR.rtpengine.rtpengine_manage0()
+
 <a target='_blank' href='/docs/modules/devel/modules/rtpengine.html#rtpengine.f.rtpengine_manage0'> `int rtpengine_manage0()` </a> 
 
-#### KSR.rtpengine.rtpengine_offer() ####
+#### KSR.rtpengine.rtpengine_offer()
+
 <a target='_blank' href='/docs/modules/devel/modules/rtpengine.html#rtpengine.f.rtpengine_offer'> `int rtpengine_offer(str "flags")` </a> 
 
-#### KSR.rtpengine.rtpengine_offer0() ####
+#### KSR.rtpengine.rtpengine_offer0()
+
 <a target='_blank' href='/docs/modules/devel/modules/rtpengine.html#rtpengine.f.rtpengine_offer0'> `int rtpengine_offer0()` </a> 
 
-#### KSR.rtpengine.set_rtpengine_set() ####
+#### KSR.rtpengine.set_rtpengine_set()
+
 <a target='_blank' href='/docs/modules/devel/modules/rtpengine.html#rtpengine.f.set_rtpengine_set'> `int set_rtpengine_set(int r1)` </a> 
 
-#### KSR.rtpengine.set_rtpengine_set2() ####
+#### KSR.rtpengine.set_rtpengine_set2()
+
 <a target='_blank' href='/docs/modules/devel/modules/rtpengine.html#rtpengine.f.set_rtpengine_set2'> `int set_rtpengine_set2(int r1, int r2)` </a> 
 
-#### KSR.rtpengine.start_recording() ####
+This function is the sibling function to [set_rtpengine_set()](#ksrrtpengineset_rtpengine_set). The original module function is declared as
+`set_rtpengine_set(setid[, setid])`.
+
+In KEMI set_rtpengine_set() takes only the first parameter and set_rtpengine_set2() allows for the second optional parameter to be passed.
+
+```
+KSR.rtpengine.set_rtpengine_set(2, 1);
+KSR.rtpengine.rtpengine_offer();
+```
+
+Please review the documentation for [set_rtpengine_set()](#ksrrtpengineset_rtpengine_set) for more information.
+#### KSR.rtpengine.start_recording()
+
 <a target='_blank' href='/docs/modules/devel/modules/rtpengine.html#rtpengine.f.start_recording'> `int start_recording()` </a> 
 
-#### KSR.rtpengine.stop_recording() ####
+#### KSR.rtpengine.stop_recording()
+
 <a target='_blank' href='/docs/modules/devel/modules/rtpengine.html#rtpengine.f.stop_recording'> `int stop_recording()` </a> 
 
-## rtpproxy ##
-#### KSR.rtpproxy.rtpproxy_answer() ####
+## rtpproxy
+
+#### KSR.rtpproxy.rtpproxy_answer()
+
 <a target='_blank' href='/docs/modules/devel/modules/rtpproxy.html#rtpproxy.f.rtpproxy_answer'> `int rtpproxy_answer(str "flags")` </a> 
 
-#### KSR.rtpproxy.rtpproxy_answer0() ####
+#### KSR.rtpproxy.rtpproxy_answer0()
+
 <a target='_blank' href='/docs/modules/devel/modules/rtpproxy.html#rtpproxy.f.rtpproxy_answer0'> `int rtpproxy_answer0()` </a> 
 
-#### KSR.rtpproxy.rtpproxy_answer_ip() ####
+#### KSR.rtpproxy.rtpproxy_answer_ip()
+
 <a target='_blank' href='/docs/modules/devel/modules/rtpproxy.html#rtpproxy.f.rtpproxy_answer_ip'> `int rtpproxy_answer_ip(str "flags", str "mip")` </a> 
 
-#### KSR.rtpproxy.rtpproxy_destroy() ####
+#### KSR.rtpproxy.rtpproxy_destroy()
+
 <a target='_blank' href='/docs/modules/devel/modules/rtpproxy.html#rtpproxy.f.rtpproxy_destroy'> `int rtpproxy_destroy(str "flags")` </a> 
 
-#### KSR.rtpproxy.rtpproxy_destroy0() ####
+#### KSR.rtpproxy.rtpproxy_destroy0()
+
 <a target='_blank' href='/docs/modules/devel/modules/rtpproxy.html#rtpproxy.f.rtpproxy_destroy0'> `int rtpproxy_destroy0()` </a> 
 
-#### KSR.rtpproxy.rtpproxy_manage() ####
+#### KSR.rtpproxy.rtpproxy_manage()
+
 <a target='_blank' href='/docs/modules/devel/modules/rtpproxy.html#rtpproxy.f.rtpproxy_manage'> `int rtpproxy_manage(str "flags")` </a> 
 
-#### KSR.rtpproxy.rtpproxy_manage0() ####
+#### KSR.rtpproxy.rtpproxy_manage0()
+
 <a target='_blank' href='/docs/modules/devel/modules/rtpproxy.html#rtpproxy.f.rtpproxy_manage0'> `int rtpproxy_manage0()` </a> 
 
-#### KSR.rtpproxy.rtpproxy_manage_ip() ####
+#### KSR.rtpproxy.rtpproxy_manage_ip()
+
 <a target='_blank' href='/docs/modules/devel/modules/rtpproxy.html#rtpproxy.f.rtpproxy_manage_ip'> `int rtpproxy_manage_ip(str "flags", str "mip")` </a> 
 
-#### KSR.rtpproxy.rtpproxy_offer() ####
+#### KSR.rtpproxy.rtpproxy_offer()
+
 <a target='_blank' href='/docs/modules/devel/modules/rtpproxy.html#rtpproxy.f.rtpproxy_offer'> `int rtpproxy_offer(str "flags")` </a> 
 
-#### KSR.rtpproxy.rtpproxy_offer0() ####
+#### KSR.rtpproxy.rtpproxy_offer0()
+
 <a target='_blank' href='/docs/modules/devel/modules/rtpproxy.html#rtpproxy.f.rtpproxy_offer0'> `int rtpproxy_offer0()` </a> 
 
-#### KSR.rtpproxy.rtpproxy_offer_ip() ####
+#### KSR.rtpproxy.rtpproxy_offer_ip()
+
 <a target='_blank' href='/docs/modules/devel/modules/rtpproxy.html#rtpproxy.f.rtpproxy_offer_ip'> `int rtpproxy_offer_ip(str "flags", str "mip")` </a> 
 
-#### KSR.rtpproxy.rtpproxy_stop_stream2uac() ####
+#### KSR.rtpproxy.rtpproxy_stop_stream2uac()
+
 <a target='_blank' href='/docs/modules/devel/modules/rtpproxy.html#rtpproxy.f.rtpproxy_stop_stream2uac'> `int rtpproxy_stop_stream2uac()` </a> 
 
-#### KSR.rtpproxy.rtpproxy_stop_stream2uas() ####
+#### KSR.rtpproxy.rtpproxy_stop_stream2uas()
+
 <a target='_blank' href='/docs/modules/devel/modules/rtpproxy.html#rtpproxy.f.rtpproxy_stop_stream2uas'> `int rtpproxy_stop_stream2uas()` </a> 
 
-#### KSR.rtpproxy.rtpproxy_stream2uac() ####
+#### KSR.rtpproxy.rtpproxy_stream2uac()
+
 <a target='_blank' href='/docs/modules/devel/modules/rtpproxy.html#rtpproxy.f.rtpproxy_stream2uac'> `int rtpproxy_stream2uac(str "pname", int count)` </a> 
 
-#### KSR.rtpproxy.rtpproxy_stream2uas() ####
+#### KSR.rtpproxy.rtpproxy_stream2uas()
+
 <a target='_blank' href='/docs/modules/devel/modules/rtpproxy.html#rtpproxy.f.rtpproxy_stream2uas'> `int rtpproxy_stream2uas(str "pname", int count)` </a> 
 
-#### KSR.rtpproxy.set_rtpproxy_set() ####
+#### KSR.rtpproxy.set_rtpproxy_set()
+
 <a target='_blank' href='/docs/modules/devel/modules/rtpproxy.html#rtpproxy.f.set_rtpproxy_set'> `int set_rtpproxy_set(int rset)` </a> 
 
-#### KSR.rtpproxy.start_recording() ####
+#### KSR.rtpproxy.start_recording()
+
 <a target='_blank' href='/docs/modules/devel/modules/rtpproxy.html#rtpproxy.f.start_recording'> `int start_recording()` </a> 
 
-## sanity ##
-#### KSR.sanity.sanity_check() ####
+## sanity
+
+#### KSR.sanity.sanity_check()
+
 <a target='_blank' href='/docs/modules/devel/modules/sanity.html#sanity.f.sanity_check'> `int sanity_check(int mflags, int uflags)` </a> 
 
-#### KSR.sanity.sanity_check_defaults() ####
+#### KSR.sanity.sanity_check_defaults()
+
 <a target='_blank' href='/docs/modules/devel/modules/sanity.html#sanity.f.sanity_check_defaults'> `int sanity_check_defaults()` </a> 
 
-## sdpops ##
-#### KSR.sdpops.keep_codecs_by_id() ####
+## sdpops
+
+#### KSR.sdpops.keep_codecs_by_id()
+
 <a target='_blank' href='/docs/modules/devel/modules/sdpops.html#sdpops.f.keep_codecs_by_id'> `int keep_codecs_by_id(str "codecs", str "media")` </a> 
 
-#### KSR.sdpops.keep_codecs_by_name() ####
+#### KSR.sdpops.keep_codecs_by_name()
+
 <a target='_blank' href='/docs/modules/devel/modules/sdpops.html#sdpops.f.keep_codecs_by_name'> `int keep_codecs_by_name(str "codecs", str "media")` </a> 
 
-#### KSR.sdpops.remove_codecs_by_id() ####
+#### KSR.sdpops.remove_codecs_by_id()
+
 <a target='_blank' href='/docs/modules/devel/modules/sdpops.html#sdpops.f.remove_codecs_by_id'> `int remove_codecs_by_id(str "codecs", str "media")` </a> 
 
-#### KSR.sdpops.remove_codecs_by_name() ####
+#### KSR.sdpops.remove_codecs_by_name()
+
 <a target='_blank' href='/docs/modules/devel/modules/sdpops.html#sdpops.f.remove_codecs_by_name'> `int remove_codecs_by_name(str "codecs", str "media")` </a> 
 
-#### KSR.sdpops.remove_line_by_prefix() ####
+#### KSR.sdpops.remove_line_by_prefix()
+
 <a target='_blank' href='/docs/modules/devel/modules/sdpops.html#sdpops.f.remove_line_by_prefix'> `int remove_line_by_prefix(str "prefix", str "media")` </a> 
 
-#### KSR.sdpops.remove_media() ####
+#### KSR.sdpops.remove_media()
+
 <a target='_blank' href='/docs/modules/devel/modules/sdpops.html#sdpops.f.remove_media'> `int remove_media(str "media")` </a> 
 
-#### KSR.sdpops.sdp_content() ####
+#### KSR.sdpops.sdp_content()
+
 <a target='_blank' href='/docs/modules/devel/modules/sdpops.html#sdpops.f.sdp_content'> `int sdp_content()` </a> 
 
-#### KSR.sdpops.sdp_content_flags() ####
+#### KSR.sdpops.sdp_content_flags()
+
 <a target='_blank' href='/docs/modules/devel/modules/sdpops.html#sdpops.f.sdp_content_flags'> `int sdp_content_flags(int flags)` </a> 
 
-#### KSR.sdpops.sdp_get() ####
+#### KSR.sdpops.sdp_get()
+
 <a target='_blank' href='/docs/modules/devel/modules/sdpops.html#sdpops.f.sdp_get'> `int sdp_get(str "avp")` </a> 
 
-#### KSR.sdpops.sdp_transport() ####
+#### KSR.sdpops.sdp_transport()
+
 <a target='_blank' href='/docs/modules/devel/modules/sdpops.html#sdpops.f.sdp_transport'> `int sdp_transport(str "avp")` </a> 
 
-#### KSR.sdpops.sdp_with_ice() ####
+#### KSR.sdpops.sdp_with_ice()
+
 <a target='_blank' href='/docs/modules/devel/modules/sdpops.html#sdpops.f.sdp_with_ice'> `int sdp_with_ice()` </a> 
 
-## sipcapture ##
-#### KSR.sipcapture.float2int() ####
+## sipcapture
+
+#### KSR.sipcapture.float2int()
+
 <a target='_blank' href='/docs/modules/devel/modules/sipcapture.html#sipcapture.f.float2int'> `int float2int(str "_val", str "_coof")` </a> 
 
-#### KSR.sipcapture.report_capture() ####
+#### KSR.sipcapture.report_capture()
+
 <a target='_blank' href='/docs/modules/devel/modules/sipcapture.html#sipcapture.f.report_capture'> `int report_capture(str "_table")` </a> 
 
-#### KSR.sipcapture.report_capture_cid() ####
+#### KSR.sipcapture.report_capture_cid()
+
 <a target='_blank' href='/docs/modules/devel/modules/sipcapture.html#sipcapture.f.report_capture_cid'> `int report_capture_cid(str "_table", str "_cid")` </a> 
 
-#### KSR.sipcapture.report_capture_data() ####
+#### KSR.sipcapture.report_capture_data()
+
 <a target='_blank' href='/docs/modules/devel/modules/sipcapture.html#sipcapture.f.report_capture_data'> `int report_capture_data(str "_table", str "_cid", str "_data")` </a> 
 
-#### KSR.sipcapture.sip_capture() ####
+#### KSR.sipcapture.sip_capture()
+
 <a target='_blank' href='/docs/modules/devel/modules/sipcapture.html#sipcapture.f.sip_capture'> `int sip_capture()` </a> 
 
-#### KSR.sipcapture.sip_capture_mode() ####
+#### KSR.sipcapture.sip_capture_mode()
+
 <a target='_blank' href='/docs/modules/devel/modules/sipcapture.html#sipcapture.f.sip_capture_mode'> `int sip_capture_mode(str "_table", str "_cmdata")` </a> 
 
-#### KSR.sipcapture.sip_capture_table() ####
+#### KSR.sipcapture.sip_capture_table()
+
 <a target='_blank' href='/docs/modules/devel/modules/sipcapture.html#sipcapture.f.sip_capture_table'> `int sip_capture_table(str "_table")` </a> 
 
-## sipdump ##
-#### KSR.sipdump.send() ####
+## sipdump
+
+#### KSR.sipdump.send()
+
 <a target='_blank' href='/docs/modules/devel/modules/sipdump.html#sipdump.f.send'> `int send(str "stag")` </a> 
 
-## siptrace ##
-#### KSR.siptrace.hlog() ####
+## siptrace
+
+#### KSR.siptrace.hlog()
+
 <a target='_blank' href='/docs/modules/devel/modules/siptrace.html#siptrace.f.hlog'> `int hlog(str "message")` </a> 
 
-#### KSR.siptrace.hlog_cid() ####
+#### KSR.siptrace.hlog_cid()
+
 <a target='_blank' href='/docs/modules/devel/modules/siptrace.html#siptrace.f.hlog_cid'> `int hlog_cid(str "correlationid", str "message")` </a> 
 
-#### KSR.siptrace.sip_trace() ####
+#### KSR.siptrace.sip_trace()
+
 <a target='_blank' href='/docs/modules/devel/modules/siptrace.html#siptrace.f.sip_trace'> `int sip_trace()` </a> 
 
-#### KSR.siptrace.sip_trace_dst() ####
+#### KSR.siptrace.sip_trace_dst()
+
 <a target='_blank' href='/docs/modules/devel/modules/siptrace.html#siptrace.f.sip_trace_dst'> `int sip_trace_dst(str "duri")` </a> 
 
-#### KSR.siptrace.sip_trace_dst_cid() ####
+#### KSR.siptrace.sip_trace_dst_cid()
+
 <a target='_blank' href='/docs/modules/devel/modules/siptrace.html#siptrace.f.sip_trace_dst_cid'> `int sip_trace_dst_cid(str "duri", str "cid")` </a> 
 
-## siputils ##
-#### KSR.siputils.has_totag() ####
+## siputils
+
+#### KSR.siputils.has_totag()
+
 <a target='_blank' href='/docs/modules/devel/modules/siputils.html#siputils.f.has_totag'> `int has_totag()` </a> 
 
-#### KSR.siputils.is_first_hop() ####
+#### KSR.siputils.is_first_hop()
+
 <a target='_blank' href='/docs/modules/devel/modules/siputils.html#siputils.f.is_first_hop'> `int is_first_hop()` </a> 
 
-#### KSR.siputils.is_reply() ####
+#### KSR.siputils.is_reply()
+
 <a target='_blank' href='/docs/modules/devel/modules/siputils.html#siputils.f.is_reply'> `int is_reply()` </a> 
 
-#### KSR.siputils.is_request() ####
+#### KSR.siputils.is_request()
+
 <a target='_blank' href='/docs/modules/devel/modules/siputils.html#siputils.f.is_request'> `int is_request()` </a> 
 
-## sl ##
-#### KSR.sl.send_reply() ####
+## sl
+
+#### KSR.sl.send_reply()
+
 <a target='_blank' href='/docs/modules/devel/modules/sl.html#sl.f.send_reply'> `int send_reply(int code, str "reason")` </a> 
 
-#### KSR.sl.sl_forward_reply() ####
+#### KSR.sl.sl_forward_reply()
+
 <a target='_blank' href='/docs/modules/devel/modules/sl.html#sl.f.sl_forward_reply'> `int sl_forward_reply(str "code", str "reason")` </a> 
 
-#### KSR.sl.sl_reply_error() ####
+#### KSR.sl.sl_reply_error()
+
 <a target='_blank' href='/docs/modules/devel/modules/sl.html#sl.f.sl_reply_error'> `int sl_reply_error()` </a> 
 
-#### KSR.sl.sl_send_reply() ####
+#### KSR.sl.sl_send_reply()
+
 <a target='_blank' href='/docs/modules/devel/modules/sl.html#sl.f.sl_send_reply'> `int sl_send_reply(int code, str "reason")` </a> 
 
-## speeddial ##
-#### KSR.speeddial.lookup() ####
+## speeddial
+
+#### KSR.speeddial.lookup()
+
 <a target='_blank' href='/docs/modules/devel/modules/speeddial.html#speeddial.f.lookup'> `int lookup(str "stable")` </a> 
 
-#### KSR.speeddial.lookup_owner() ####
+#### KSR.speeddial.lookup_owner()
+
 <a target='_blank' href='/docs/modules/devel/modules/speeddial.html#speeddial.f.lookup_owner'> `int lookup_owner(str "stable", str "sowner")` </a> 
 
-## sqlops ##
-#### KSR.sqlops.sql_is_null() ####
+## sqlops
+
+#### KSR.sqlops.sql_is_null()
+
 <a target='_blank' href='/docs/modules/devel/modules/sqlops.html#sqlops.f.sql_is_null'> `int sql_is_null(str "sres", int i, int j)` </a> 
 
-#### KSR.sqlops.sql_num_columns() ####
+#### KSR.sqlops.sql_num_columns()
+
 <a target='_blank' href='/docs/modules/devel/modules/sqlops.html#sqlops.f.sql_num_columns'> `int sql_num_columns(str "sres")` </a> 
 
-#### KSR.sqlops.sql_num_rows() ####
+#### KSR.sqlops.sql_num_rows()
+
 <a target='_blank' href='/docs/modules/devel/modules/sqlops.html#sqlops.f.sql_num_rows'> `int sql_num_rows(str "sres")` </a> 
 
-#### KSR.sqlops.sql_query() ####
+#### KSR.sqlops.sql_query()
+
 <a target='_blank' href='/docs/modules/devel/modules/sqlops.html#sqlops.f.sql_query'> `int sql_query(str "scon", str "squery", str "sres")` </a> 
 
-#### KSR.sqlops.sql_result_free() ####
+#### KSR.sqlops.sql_result_free()
+
 <a target='_blank' href='/docs/modules/devel/modules/sqlops.html#sqlops.f.sql_result_free'> `int sql_result_free(str "sres")` </a> 
 
-#### KSR.sqlops.sql_xquery() ####
+#### KSR.sqlops.sql_xquery()
+
 <a target='_blank' href='/docs/modules/devel/modules/sqlops.html#sqlops.f.sql_xquery'> `int sql_xquery(str "scon", str "squery", str "xavp")` </a> 
 
-## ss7ops ##
-#### KSR.ss7ops.isup_to_json() ####
+## ss7ops
+
+#### KSR.ss7ops.isup_to_json()
+
 <a target='_blank' href='/docs/modules/devel/modules/ss7ops.html#ss7ops.f.isup_to_json'> `int isup_to_json(int proto)` </a> 
 
-## sst ##
-#### KSR.sst.sst_check_min() ####
+## sst
+
+#### KSR.sst.sst_check_min()
+
 <a target='_blank' href='/docs/modules/devel/modules/sst.html#sst.f.sst_check_min'> `int sst_check_min(int flag)` </a> 
 
-## statistics ##
-#### KSR.statistics.reset_stat() ####
+## statistics
+
+#### KSR.statistics.reset_stat()
+
 <a target='_blank' href='/docs/modules/devel/modules/statistics.html#statistics.f.reset_stat'> `int reset_stat(str "sname")` </a> 
 
-#### KSR.statistics.update_stat() ####
+#### KSR.statistics.update_stat()
+
 <a target='_blank' href='/docs/modules/devel/modules/statistics.html#statistics.f.update_stat'> `int update_stat(str "sname", int sval)` </a> 
 
-## statsc ##
-#### KSR.statsc.statsc_reset() ####
+## statsc
+
+#### KSR.statsc.statsc_reset()
+
 <a target='_blank' href='/docs/modules/devel/modules/statsc.html#statsc.f.statsc_reset'> `int statsc_reset()` </a> 
 
-## statsd ##
-#### KSR.statsd.statsd_decr() ####
+## statsd
+
+#### KSR.statsd.statsd_decr()
+
 <a target='_blank' href='/docs/modules/devel/modules/statsd.html#statsd.f.statsd_decr'> `int statsd_decr(str "key")` </a> 
 
-#### KSR.statsd.statsd_gauge() ####
+#### KSR.statsd.statsd_gauge()
+
 <a target='_blank' href='/docs/modules/devel/modules/statsd.html#statsd.f.statsd_gauge'> `int statsd_gauge(str "key", str "val")` </a> 
 
-#### KSR.statsd.statsd_incr() ####
+#### KSR.statsd.statsd_incr()
+
 <a target='_blank' href='/docs/modules/devel/modules/statsd.html#statsd.f.statsd_incr'> `int statsd_incr(str "key")` </a> 
 
-#### KSR.statsd.statsd_set() ####
+#### KSR.statsd.statsd_set()
+
 <a target='_blank' href='/docs/modules/devel/modules/statsd.html#statsd.f.statsd_set'> `int statsd_set(str "key", str "val")` </a> 
 
-#### KSR.statsd.statsd_start() ####
+#### KSR.statsd.statsd_start()
+
 <a target='_blank' href='/docs/modules/devel/modules/statsd.html#statsd.f.statsd_start'> `int statsd_start(str "key")` </a> 
 
-#### KSR.statsd.statsd_stop() ####
+#### KSR.statsd.statsd_stop()
+
 <a target='_blank' href='/docs/modules/devel/modules/statsd.html#statsd.f.statsd_stop'> `int statsd_stop(str "key")` </a> 
 
-## textops ##
-#### KSR.textops.cmp_istr() ####
+## textops
+
+#### KSR.textops.cmp_istr()
+
 <a target='_blank' href='/docs/modules/devel/modules/textops.html#textops.f.cmp_istr'> `int cmp_istr(str "s1", str "s2")` </a> 
 
-#### KSR.textops.cmp_str() ####
+#### KSR.textops.cmp_str()
+
 <a target='_blank' href='/docs/modules/devel/modules/textops.html#textops.f.cmp_str'> `int cmp_str(str "s1", str "s2")` </a> 
 
-#### KSR.textops.filter_body() ####
+#### KSR.textops.filter_body()
+
 <a target='_blank' href='/docs/modules/devel/modules/textops.html#textops.f.filter_body'> `int filter_body(str "content_type")` </a> 
 
-#### KSR.textops.has_body() ####
+#### KSR.textops.has_body()
+
 <a target='_blank' href='/docs/modules/devel/modules/textops.html#textops.f.has_body'> `int has_body()` </a> 
 
-#### KSR.textops.has_body_type() ####
+#### KSR.textops.has_body_type()
+
 <a target='_blank' href='/docs/modules/devel/modules/textops.html#textops.f.has_body_type'> `int has_body_type(str "ctype")` </a> 
 
-#### KSR.textops.is_audio_on_hold() ####
+#### KSR.textops.is_audio_on_hold()
+
 <a target='_blank' href='/docs/modules/devel/modules/textops.html#textops.f.is_audio_on_hold'> `int is_audio_on_hold()` </a> 
 
-#### KSR.textops.is_list() ####
+#### KSR.textops.is_list()
+
 <a target='_blank' href='/docs/modules/devel/modules/textops.html#textops.f.is_list'> `int is_list(str "subject", str "list", str "vsep")` </a> 
 
-#### KSR.textops.is_present_hf() ####
+#### KSR.textops.is_present_hf()
+
 <a target='_blank' href='/docs/modules/devel/modules/textops.html#textops.f.is_present_hf'> `int is_present_hf(str "hname")` </a> 
 
-#### KSR.textops.is_present_hf_re() ####
+#### KSR.textops.is_present_hf_re()
+
 <a target='_blank' href='/docs/modules/devel/modules/textops.html#textops.f.is_present_hf_re'> `int is_present_hf_re(str "ematch")` </a> 
 
-#### KSR.textops.is_privacy() ####
+#### KSR.textops.is_privacy()
+
 <a target='_blank' href='/docs/modules/devel/modules/textops.html#textops.f.is_privacy'> `int is_privacy(str "privacy")` </a> 
 
-#### KSR.textops.remove_hf_exp() ####
+#### KSR.textops.remove_hf_exp()
+
 <a target='_blank' href='/docs/modules/devel/modules/textops.html#textops.f.remove_hf_exp'> `int remove_hf_exp(str "ematch", str "eskip")` </a> 
 
-#### KSR.textops.remove_hf_re() ####
+#### KSR.textops.remove_hf_re()
+
 <a target='_blank' href='/docs/modules/devel/modules/textops.html#textops.f.remove_hf_re'> `int remove_hf_re(str "ematch")` </a> 
 
-#### KSR.textops.replace() ####
+#### KSR.textops.replace()
+
 <a target='_blank' href='/docs/modules/devel/modules/textops.html#textops.f.replace'> `int replace(str "sre", str "sval")` </a> 
 
-#### KSR.textops.replace_all() ####
+#### KSR.textops.replace_all()
+
 <a target='_blank' href='/docs/modules/devel/modules/textops.html#textops.f.replace_all'> `int replace_all(str "sre", str "sval")` </a> 
 
-#### KSR.textops.replace_body() ####
+#### KSR.textops.replace_body()
+
 <a target='_blank' href='/docs/modules/devel/modules/textops.html#textops.f.replace_body'> `int replace_body(str "sre", str "sval")` </a> 
 
-#### KSR.textops.replace_body_all() ####
+#### KSR.textops.replace_body_all()
+
 <a target='_blank' href='/docs/modules/devel/modules/textops.html#textops.f.replace_body_all'> `int replace_body_all(str "sre", str "sval")` </a> 
 
-#### KSR.textops.replace_body_atonce() ####
+#### KSR.textops.replace_body_atonce()
+
 <a target='_blank' href='/docs/modules/devel/modules/textops.html#textops.f.replace_body_atonce'> `int replace_body_atonce(str "sre", str "sval")` </a> 
 
-#### KSR.textops.search() ####
+#### KSR.textops.search()
+
 <a target='_blank' href='/docs/modules/devel/modules/textops.html#textops.f.search'> `int search(str "sre")` </a> 
 
-#### KSR.textops.search_append() ####
+#### KSR.textops.search_append()
+
 <a target='_blank' href='/docs/modules/devel/modules/textops.html#textops.f.search_append'> `int search_append(str "ematch", str "val")` </a> 
 
-#### KSR.textops.search_append_body() ####
+#### KSR.textops.search_append_body()
+
 <a target='_blank' href='/docs/modules/devel/modules/textops.html#textops.f.search_append_body'> `int search_append_body(str "ematch", str "val")` </a> 
 
-#### KSR.textops.search_body() ####
+#### KSR.textops.search_body()
+
 <a target='_blank' href='/docs/modules/devel/modules/textops.html#textops.f.search_body'> `int search_body(str "sre")` </a> 
 
-#### KSR.textops.search_hf() ####
+#### KSR.textops.search_hf()
+
 <a target='_blank' href='/docs/modules/devel/modules/textops.html#textops.f.search_hf'> `int search_hf(str "hname", str "sre", str "flags")` </a> 
 
-#### KSR.textops.set_body() ####
+#### KSR.textops.set_body()
+
 <a target='_blank' href='/docs/modules/devel/modules/textops.html#textops.f.set_body'> `int set_body(str "nb", str "nc")` </a> 
 
-#### KSR.textops.set_reply_body() ####
+#### KSR.textops.set_reply_body()
+
 <a target='_blank' href='/docs/modules/devel/modules/textops.html#textops.f.set_reply_body'> `int set_reply_body(str "nb", str "nc")` </a> 
 
-#### KSR.textops.starts_with() ####
+#### KSR.textops.starts_with()
+
 <a target='_blank' href='/docs/modules/devel/modules/textops.html#textops.f.starts_with'> `int starts_with(str "s1", str "s2")` </a> 
 
-#### KSR.textops.subst() ####
+#### KSR.textops.subst()
+
 <a target='_blank' href='/docs/modules/devel/modules/textops.html#textops.f.subst'> `int subst(str "subst")` </a> 
 
-#### KSR.textops.subst_body() ####
+#### KSR.textops.subst_body()
+
 <a target='_blank' href='/docs/modules/devel/modules/textops.html#textops.f.subst_body'> `int subst_body(str "subst")` </a> 
 
-#### KSR.textops.subst_hf() ####
+#### KSR.textops.subst_hf()
+
 <a target='_blank' href='/docs/modules/devel/modules/textops.html#textops.f.subst_hf'> `int subst_hf(str "hname", str "subst", str "flags")` </a> 
 
-#### KSR.textops.subst_uri() ####
+#### KSR.textops.subst_uri()
+
 <a target='_blank' href='/docs/modules/devel/modules/textops.html#textops.f.subst_uri'> `int subst_uri(str "subst")` </a> 
 
-#### KSR.textops.subst_user() ####
+#### KSR.textops.subst_user()
+
 <a target='_blank' href='/docs/modules/devel/modules/textops.html#textops.f.subst_user'> `int subst_user(str "subst")` </a> 
 
-## textopsx ##
-#### KSR.textopsx.append_hf_value() ####
+## textopsx
+
+#### KSR.textopsx.append_hf_value()
+
 <a target='_blank' href='/docs/modules/devel/modules/textopsx.html#textopsx.f.append_hf_value'> `int append_hf_value(str "hexp", str "val")` </a> 
 
-#### KSR.textopsx.assign_hf_value() ####
+#### KSR.textopsx.assign_hf_value()
+
 <a target='_blank' href='/docs/modules/devel/modules/textopsx.html#textopsx.f.assign_hf_value'> `int assign_hf_value(str "hexp", str "val")` </a> 
 
-#### KSR.textopsx.assign_hf_value2() ####
+#### KSR.textopsx.assign_hf_value2()
+
 <a target='_blank' href='/docs/modules/devel/modules/textopsx.html#textopsx.f.assign_hf_value2'> `int assign_hf_value2(str "hexp", str "val")` </a> 
 
-#### KSR.textopsx.change_reply_status() ####
+#### KSR.textopsx.change_reply_status()
+
 <a target='_blank' href='/docs/modules/devel/modules/textopsx.html#textopsx.f.change_reply_status'> `int change_reply_status(int code, str "reason")` </a> 
 
-#### KSR.textopsx.exclude_hf_value() ####
+#### KSR.textopsx.exclude_hf_value()
+
 <a target='_blank' href='/docs/modules/devel/modules/textopsx.html#textopsx.f.exclude_hf_value'> `int exclude_hf_value(str "hexp", str "val")` </a> 
 
-#### KSR.textopsx.fnmatch() ####
+#### KSR.textopsx.fnmatch()
+
 <a target='_blank' href='/docs/modules/devel/modules/textopsx.html#textopsx.f.fnmatch'> `int fnmatch(str "val", str "match")` </a> 
 
-#### KSR.textopsx.fnmatch_ex() ####
+#### KSR.textopsx.fnmatch_ex()
+
 <a target='_blank' href='/docs/modules/devel/modules/textopsx.html#textopsx.f.fnmatch_ex'> `int fnmatch_ex(str "val", str "match", str "flags")` </a> 
 
-#### KSR.textopsx.hf_value_exists() ####
+#### KSR.textopsx.hf_value_exists()
+
 <a target='_blank' href='/docs/modules/devel/modules/textopsx.html#textopsx.f.hf_value_exists'> `int hf_value_exists(str "hexp", str "val")` </a> 
 
-#### KSR.textopsx.include_hf_value() ####
+#### KSR.textopsx.include_hf_value()
+
 <a target='_blank' href='/docs/modules/devel/modules/textopsx.html#textopsx.f.include_hf_value'> `int include_hf_value(str "hexp", str "val")` </a> 
 
-#### KSR.textopsx.insert_hf_value() ####
+#### KSR.textopsx.insert_hf_value()
+
 <a target='_blank' href='/docs/modules/devel/modules/textopsx.html#textopsx.f.insert_hf_value'> `int insert_hf_value(str "hexp", str "val")` </a> 
 
-#### KSR.textopsx.keep_hf() ####
+#### KSR.textopsx.keep_hf()
+
 <a target='_blank' href='/docs/modules/devel/modules/textopsx.html#textopsx.f.keep_hf'> `int keep_hf()` </a> 
 
-#### KSR.textopsx.keep_hf_re() ####
+#### KSR.textopsx.keep_hf_re()
+
 <a target='_blank' href='/docs/modules/devel/modules/textopsx.html#textopsx.f.keep_hf_re'> `int keep_hf_re(str "sre")` </a> 
 
-#### KSR.textopsx.msg_apply_changes() ####
+#### KSR.textopsx.msg_apply_changes()
+
 <a target='_blank' href='/docs/modules/devel/modules/textopsx.html#textopsx.f.msg_apply_changes'> `int msg_apply_changes()` </a> 
 
-#### KSR.textopsx.msg_set_buffer() ####
+#### KSR.textopsx.msg_set_buffer()
+
 <a target='_blank' href='/docs/modules/devel/modules/textopsx.html#textopsx.f.msg_set_buffer'> `int msg_set_buffer(str "obuf")` </a> 
 
-#### KSR.textopsx.remove_body() ####
+#### KSR.textopsx.remove_body()
+
 <a target='_blank' href='/docs/modules/devel/modules/textopsx.html#textopsx.f.remove_body'> `int remove_body()` </a> 
 
-#### KSR.textopsx.remove_hf_value() ####
+#### KSR.textopsx.remove_hf_value()
+
 <a target='_blank' href='/docs/modules/devel/modules/textopsx.html#textopsx.f.remove_hf_value'> `int remove_hf_value(str "hexp")` </a> 
 
-#### KSR.textopsx.remove_hf_value2() ####
+#### KSR.textopsx.remove_hf_value2()
+
 <a target='_blank' href='/docs/modules/devel/modules/textopsx.html#textopsx.f.remove_hf_value2'> `int remove_hf_value2(str "hexp", str "val")` </a> 
 
-## tls ##
-#### KSR.tls.is_peer_verified() ####
+## tls
+
+#### KSR.tls.is_peer_verified()
+
 <a target='_blank' href='/docs/modules/devel/modules/tls.html#tls.f.is_peer_verified'> `int is_peer_verified()` </a> 
 
-## tm ##
-#### KSR.tm.t_any_replied() ####
+## tm
+
+#### KSR.tm.t_any_replied()
+
 <a target='_blank' href='/docs/modules/devel/modules/tm.html#tm.f.t_any_replied'> `int t_any_replied()` </a> 
 
-#### KSR.tm.t_any_timeout() ####
+#### KSR.tm.t_any_timeout()
+
 <a target='_blank' href='/docs/modules/devel/modules/tm.html#tm.f.t_any_timeout'> `int t_any_timeout()` </a> 
 
-#### KSR.tm.t_branch_replied() ####
+#### KSR.tm.t_branch_replied()
+
 <a target='_blank' href='/docs/modules/devel/modules/tm.html#tm.f.t_branch_replied'> `int t_branch_replied()` </a> 
 
-#### KSR.tm.t_branch_timeout() ####
+#### KSR.tm.t_branch_timeout()
+
 <a target='_blank' href='/docs/modules/devel/modules/tm.html#tm.f.t_branch_timeout'> `int t_branch_timeout()` </a> 
 
-#### KSR.tm.t_check_trans() ####
+#### KSR.tm.t_check_trans()
+
 <a target='_blank' href='/docs/modules/devel/modules/tm.html#tm.f.t_check_trans'> `int t_check_trans()` </a> 
 
-#### KSR.tm.t_drop_replies() ####
+#### KSR.tm.t_drop_replies()
+
 <a target='_blank' href='/docs/modules/devel/modules/tm.html#tm.f.t_drop_replies'> `int t_drop_replies(str "mode")` </a> 
 
-#### KSR.tm.t_drop_replies_all() ####
+#### KSR.tm.t_drop_replies_all()
+
 <a target='_blank' href='/docs/modules/devel/modules/tm.html#tm.f.t_drop_replies_all'> `int t_drop_replies_all()` </a> 
 
-#### KSR.tm.t_grep_status() ####
+#### KSR.tm.t_grep_status()
+
 <a target='_blank' href='/docs/modules/devel/modules/tm.html#tm.f.t_grep_status'> `int t_grep_status(int code)` </a> 
 
-#### KSR.tm.t_is_canceled() ####
+#### KSR.tm.t_is_canceled()
+
 <a target='_blank' href='/docs/modules/devel/modules/tm.html#tm.f.t_is_canceled'> `int t_is_canceled()` </a> 
 
-#### KSR.tm.t_is_expired() ####
+#### KSR.tm.t_is_expired()
+
 <a target='_blank' href='/docs/modules/devel/modules/tm.html#tm.f.t_is_expired'> `int t_is_expired()` </a> 
 
-#### KSR.tm.t_is_retr_async_reply() ####
+#### KSR.tm.t_is_retr_async_reply()
+
 <a target='_blank' href='/docs/modules/devel/modules/tm.html#tm.f.t_is_retr_async_reply'> `int t_is_retr_async_reply()` </a> 
 
-#### KSR.tm.t_is_set() ####
+#### KSR.tm.t_is_set()
+
 <a target='_blank' href='/docs/modules/devel/modules/tm.html#tm.f.t_is_set'> `int t_is_set(str "target")` </a> 
 
-#### KSR.tm.t_load_contacts() ####
+#### KSR.tm.t_load_contacts()
+
 <a target='_blank' href='/docs/modules/devel/modules/tm.html#tm.f.t_load_contacts'> `int t_load_contacts()` </a> 
 
-#### KSR.tm.t_lookup_cancel() ####
+#### KSR.tm.t_lookup_cancel()
+
 <a target='_blank' href='/docs/modules/devel/modules/tm.html#tm.f.t_lookup_cancel'> `int t_lookup_cancel()` </a> 
 
-#### KSR.tm.t_lookup_cancel_flags() ####
+#### KSR.tm.t_lookup_cancel_flags()
+
 <a target='_blank' href='/docs/modules/devel/modules/tm.html#tm.f.t_lookup_cancel_flags'> `int t_lookup_cancel_flags(int flags)` </a> 
 
-#### KSR.tm.t_lookup_request() ####
+#### KSR.tm.t_lookup_request()
+
 <a target='_blank' href='/docs/modules/devel/modules/tm.html#tm.f.t_lookup_request'> `int t_lookup_request()` </a> 
 
-#### KSR.tm.t_newtran() ####
+#### KSR.tm.t_newtran()
+
 <a target='_blank' href='/docs/modules/devel/modules/tm.html#tm.f.t_newtran'> `int t_newtran()` </a> 
 
-#### KSR.tm.t_next_contact_flow() ####
+#### KSR.tm.t_next_contact_flow()
+
 <a target='_blank' href='/docs/modules/devel/modules/tm.html#tm.f.t_next_contact_flow'> `int t_next_contact_flow()` </a> 
 
-#### KSR.tm.t_next_contacts() ####
+#### KSR.tm.t_next_contacts()
+
 <a target='_blank' href='/docs/modules/devel/modules/tm.html#tm.f.t_next_contacts'> `int t_next_contacts()` </a> 
 
-#### KSR.tm.t_on_branch() ####
+#### KSR.tm.t_on_branch()
+
 <a target='_blank' href='/docs/modules/devel/modules/tm.html#tm.f.t_on_branch'> `int t_on_branch(str "rname")` </a> 
 
-#### KSR.tm.t_on_branch_failure() ####
+#### KSR.tm.t_on_branch_failure()
+
 <a target='_blank' href='/docs/modules/devel/modules/tm.html#tm.f.t_on_branch_failure'> `int t_on_branch_failure(str "rname")` </a> 
 
-#### KSR.tm.t_on_failure() ####
+#### KSR.tm.t_on_failure()
+
 <a target='_blank' href='/docs/modules/devel/modules/tm.html#tm.f.t_on_failure'> `int t_on_failure(str "rname")` </a> 
 
-#### KSR.tm.t_on_reply() ####
+#### KSR.tm.t_on_reply()
+
 <a target='_blank' href='/docs/modules/devel/modules/tm.html#tm.f.t_on_reply'> `int t_on_reply(str "rname")` </a> 
 
-#### KSR.tm.t_relay() ####
+#### KSR.tm.t_relay()
+
 <a target='_blank' href='/docs/modules/devel/modules/tm.html#tm.f.t_relay'> `int t_relay()` </a> 
 
-#### KSR.tm.t_release() ####
+#### KSR.tm.t_release()
+
 <a target='_blank' href='/docs/modules/devel/modules/tm.html#tm.f.t_release'> `int t_release()` </a> 
 
-#### KSR.tm.t_replicate() ####
+#### KSR.tm.t_replicate()
+
 <a target='_blank' href='/docs/modules/devel/modules/tm.html#tm.f.t_replicate'> `int t_replicate(str "suri")` </a> 
 
-#### KSR.tm.t_reply() ####
+#### KSR.tm.t_reply()
+
 <a target='_blank' href='/docs/modules/devel/modules/tm.html#tm.f.t_reply'> `int t_reply(int code, str "reason")` </a> 
 
-#### KSR.tm.t_reset_fr() ####
+#### KSR.tm.t_reset_fr()
+
 <a target='_blank' href='/docs/modules/devel/modules/tm.html#tm.f.t_reset_fr'> `int t_reset_fr()` </a> 
 
-#### KSR.tm.t_reset_max_lifetime() ####
+#### KSR.tm.t_reset_max_lifetime()
+
 <a target='_blank' href='/docs/modules/devel/modules/tm.html#tm.f.t_reset_max_lifetime'> `int t_reset_max_lifetime()` </a> 
 
-#### KSR.tm.t_reset_retr() ####
+#### KSR.tm.t_reset_retr()
+
 <a target='_blank' href='/docs/modules/devel/modules/tm.html#tm.f.t_reset_retr'> `int t_reset_retr()` </a> 
 
-#### KSR.tm.t_retransmit_reply() ####
+#### KSR.tm.t_retransmit_reply()
+
 <a target='_blank' href='/docs/modules/devel/modules/tm.html#tm.f.t_retransmit_reply'> `int t_retransmit_reply()` </a> 
 
-#### KSR.tm.t_save_lumps() ####
+#### KSR.tm.t_save_lumps()
+
 <a target='_blank' href='/docs/modules/devel/modules/tm.html#tm.f.t_save_lumps'> `int t_save_lumps()` </a> 
 
-#### KSR.tm.t_set_auto_inv_100() ####
+#### KSR.tm.t_set_auto_inv_100()
+
 <a target='_blank' href='/docs/modules/devel/modules/tm.html#tm.f.t_set_auto_inv_100'> `int t_set_auto_inv_100(int state)` </a> 
 
-#### KSR.tm.t_set_disable_6xx() ####
+#### KSR.tm.t_set_disable_6xx()
+
 <a target='_blank' href='/docs/modules/devel/modules/tm.html#tm.f.t_set_disable_6xx'> `int t_set_disable_6xx(int state)` </a> 
 
-#### KSR.tm.t_set_disable_failover() ####
+#### KSR.tm.t_set_disable_failover()
+
 <a target='_blank' href='/docs/modules/devel/modules/tm.html#tm.f.t_set_disable_failover'> `int t_set_disable_failover(int state)` </a> 
 
-#### KSR.tm.t_set_disable_internal_reply() ####
+#### KSR.tm.t_set_disable_internal_reply()
+
 <a target='_blank' href='/docs/modules/devel/modules/tm.html#tm.f.t_set_disable_internal_reply'> `int t_set_disable_internal_reply(int state)` </a> 
 
-#### KSR.tm.t_set_fr() ####
+#### KSR.tm.t_set_fr()
+
 <a target='_blank' href='/docs/modules/devel/modules/tm.html#tm.f.t_set_fr'> `int t_set_fr(int fr_inv, int fr)` </a> 
 
-#### KSR.tm.t_set_fr_inv() ####
+#### KSR.tm.t_set_fr_inv()
+
 <a target='_blank' href='/docs/modules/devel/modules/tm.html#tm.f.t_set_fr_inv'> `int t_set_fr_inv(int fr_inv)` </a> 
 
-#### KSR.tm.t_set_max_lifetime() ####
+#### KSR.tm.t_set_max_lifetime()
+
 <a target='_blank' href='/docs/modules/devel/modules/tm.html#tm.f.t_set_max_lifetime'> `int t_set_max_lifetime(int t1, int t2)` </a> 
 
-#### KSR.tm.t_set_no_e2e_cancel_reason() ####
+#### KSR.tm.t_set_no_e2e_cancel_reason()
+
 <a target='_blank' href='/docs/modules/devel/modules/tm.html#tm.f.t_set_no_e2e_cancel_reason'> `int t_set_no_e2e_cancel_reason(int state)` </a> 
 
-#### KSR.tm.t_set_retr() ####
+#### KSR.tm.t_set_retr()
+
 <a target='_blank' href='/docs/modules/devel/modules/tm.html#tm.f.t_set_retr'> `int t_set_retr(int t1, int t2)` </a> 
 
-#### KSR.tm.t_uac_send() ####
+#### KSR.tm.t_uac_send()
+
 <a target='_blank' href='/docs/modules/devel/modules/tm.html#tm.f.t_uac_send'> `int t_uac_send(str "method", str "ruri", str "nexthop", str "ssock", str "hdrs", str "body")` </a> 
 
-#### KSR.tm.t_use_uac_headers() ####
+#### KSR.tm.t_use_uac_headers()
+
 <a target='_blank' href='/docs/modules/devel/modules/tm.html#tm.f.t_use_uac_headers'> `int t_use_uac_headers()` </a> 
 
-## tmx ##
-#### KSR.tmx.t_is_branch_route() ####
+## tmx
+
+#### KSR.tmx.t_is_branch_route()
+
 <a target='_blank' href='/docs/modules/devel/modules/tmx.html#tmx.f.t_is_branch_route'> `int t_is_branch_route()` </a> 
 
-#### KSR.tmx.t_is_failure_route() ####
+#### KSR.tmx.t_is_failure_route()
+
 <a target='_blank' href='/docs/modules/devel/modules/tmx.html#tmx.f.t_is_failure_route'> `int t_is_failure_route()` </a> 
 
-#### KSR.tmx.t_is_reply_route() ####
+#### KSR.tmx.t_is_reply_route()
+
 <a target='_blank' href='/docs/modules/devel/modules/tmx.html#tmx.f.t_is_reply_route'> `int t_is_reply_route()` </a> 
 
-#### KSR.tmx.t_is_request_route() ####
+#### KSR.tmx.t_is_request_route()
+
 <a target='_blank' href='/docs/modules/devel/modules/tmx.html#tmx.f.t_is_request_route'> `int t_is_request_route()` </a> 
 
-#### KSR.tmx.t_precheck_trans() ####
+#### KSR.tmx.t_precheck_trans()
+
 <a target='_blank' href='/docs/modules/devel/modules/tmx.html#tmx.f.t_precheck_trans'> `int t_precheck_trans()` </a> 
 
-## tsilo ##
-#### KSR.tsilo.ts_append() ####
+## tsilo
+
+#### KSR.tsilo.ts_append()
+
 <a target='_blank' href='/docs/modules/devel/modules/tsilo.html#tsilo.f.ts_append'> `int ts_append(str "_table", str "_ruri")` </a> 
 
-#### KSR.tsilo.ts_append_to() ####
+#### KSR.tsilo.ts_append_to()
+
 <a target='_blank' href='/docs/modules/devel/modules/tsilo.html#tsilo.f.ts_append_to'> `int ts_append_to(int tindex, int tlabel, str "_table")` </a> 
 
-#### KSR.tsilo.ts_append_to_uri() ####
+#### KSR.tsilo.ts_append_to_uri()
+
 <a target='_blank' href='/docs/modules/devel/modules/tsilo.html#tsilo.f.ts_append_to_uri'> `int ts_append_to_uri(int tindex, int tlabel, str "_table", str "_uri")` </a> 
 
-#### KSR.tsilo.ts_store() ####
+#### KSR.tsilo.ts_store()
+
 <a target='_blank' href='/docs/modules/devel/modules/tsilo.html#tsilo.f.ts_store'> `int ts_store()` </a> 
 
-#### KSR.tsilo.ts_store_uri() ####
+#### KSR.tsilo.ts_store_uri()
+
 <a target='_blank' href='/docs/modules/devel/modules/tsilo.html#tsilo.f.ts_store_uri'> `int ts_store_uri(str "puri")` </a> 
 
-## uac ##
-#### KSR.uac.uac_auth() ####
+## uac
+
+#### KSR.uac.uac_auth()
+
 <a target='_blank' href='/docs/modules/devel/modules/uac.html#uac.f.uac_auth'> `int uac_auth()` </a> 
 
-#### KSR.uac.uac_reg_lookup() ####
+#### KSR.uac.uac_reg_lookup()
+
 <a target='_blank' href='/docs/modules/devel/modules/uac.html#uac.f.uac_reg_lookup'> `int uac_reg_lookup(str "userid", str "sdst")` </a> 
 
-#### KSR.uac.uac_reg_request_to() ####
+#### KSR.uac.uac_reg_request_to()
+
 <a target='_blank' href='/docs/modules/devel/modules/uac.html#uac.f.uac_reg_request_to'> `int uac_reg_request_to(str "userid", int imode)` </a> 
 
-#### KSR.uac.uac_reg_status() ####
+#### KSR.uac.uac_reg_status()
+
 <a target='_blank' href='/docs/modules/devel/modules/uac.html#uac.f.uac_reg_status'> `int uac_reg_status(str "sruuid")` </a> 
 
-#### KSR.uac.uac_replace_from() ####
+#### KSR.uac.uac_replace_from()
+
 <a target='_blank' href='/docs/modules/devel/modules/uac.html#uac.f.uac_replace_from'> `int uac_replace_from(str "pdsp", str "puri")` </a> 
 
-#### KSR.uac.uac_replace_from_uri() ####
+#### KSR.uac.uac_replace_from_uri()
+
 <a target='_blank' href='/docs/modules/devel/modules/uac.html#uac.f.uac_replace_from_uri'> `int uac_replace_from_uri(str "puri")` </a> 
 
-#### KSR.uac.uac_replace_to() ####
+#### KSR.uac.uac_replace_to()
+
 <a target='_blank' href='/docs/modules/devel/modules/uac.html#uac.f.uac_replace_to'> `int uac_replace_to(str "pdsp", str "puri")` </a> 
 
-#### KSR.uac.uac_replace_to_uri() ####
+#### KSR.uac.uac_replace_to_uri()
+
 <a target='_blank' href='/docs/modules/devel/modules/uac.html#uac.f.uac_replace_to_uri'> `int uac_replace_to_uri(str "puri")` </a> 
 
-#### KSR.uac.uac_req_send() ####
+#### KSR.uac.uac_req_send()
+
 <a target='_blank' href='/docs/modules/devel/modules/uac.html#uac.f.uac_req_send'> `int uac_req_send()` </a> 
 
-#### KSR.uac.uac_restore_from() ####
+#### KSR.uac.uac_restore_from()
+
 <a target='_blank' href='/docs/modules/devel/modules/uac.html#uac.f.uac_restore_from'> `int uac_restore_from()` </a> 
 
-#### KSR.uac.uac_restore_to() ####
+#### KSR.uac.uac_restore_to()
+
 <a target='_blank' href='/docs/modules/devel/modules/uac.html#uac.f.uac_restore_to'> `int uac_restore_to()` </a> 
 
-## utils ##
-#### KSR.utils.xcap_auth_status() ####
+## utils
+
+#### KSR.utils.xcap_auth_status()
+
 <a target='_blank' href='/docs/modules/devel/modules/utils.html#utils.f.xcap_auth_status'> `int xcap_auth_status(str "watcher_uri", str "presentity_uri")` </a> 
 
-## websocket ##
-#### KSR.websocket.close() ####
+## websocket
+
+#### KSR.websocket.close()
+
 <a target='_blank' href='/docs/modules/devel/modules/websocket.html#websocket.f.close'> `int close()` </a> 
 
-#### KSR.websocket.close_conid() ####
+#### KSR.websocket.close_conid()
+
 <a target='_blank' href='/docs/modules/devel/modules/websocket.html#websocket.f.close_conid'> `int close_conid(int status, str "reason", int con)` </a> 
 
-#### KSR.websocket.close_reason() ####
+#### KSR.websocket.close_reason()
+
 <a target='_blank' href='/docs/modules/devel/modules/websocket.html#websocket.f.close_reason'> `int close_reason(int status, str "reason")` </a> 
 
-#### KSR.websocket.handle_handshake() ####
+#### KSR.websocket.handle_handshake()
+
 <a target='_blank' href='/docs/modules/devel/modules/websocket.html#websocket.f.handle_handshake'> `int handle_handshake()` </a> 
 
-## xcap_server ##
-#### KSR.xcap_server.xcaps_del() ####
+## xcap_server
+
+#### KSR.xcap_server.xcaps_del()
+
 <a target='_blank' href='/docs/modules/devel/modules/xcap_server.html#xcap_server.f.xcaps_del'> `int xcaps_del(str "uri", str "path")` </a> 
 
-#### KSR.xcap_server.xcaps_get() ####
+#### KSR.xcap_server.xcaps_get()
+
 <a target='_blank' href='/docs/modules/devel/modules/xcap_server.html#xcap_server.f.xcaps_get'> `int xcaps_get(str "uri", str "path")` </a> 
 
-#### KSR.xcap_server.xcaps_put() ####
+#### KSR.xcap_server.xcaps_put()
+
 <a target='_blank' href='/docs/modules/devel/modules/xcap_server.html#xcap_server.f.xcaps_put'> `int xcaps_put(str "uri", str "path", str "pbody")` </a> 
 
-## xhttp ##
-#### KSR.xhttp.xhttp_reply() ####
+## xhttp
+
+#### KSR.xhttp.xhttp_reply()
+
 <a target='_blank' href='/docs/modules/devel/modules/xhttp.html#xhttp.f.xhttp_reply'> `int xhttp_reply(int code, str "reason", str "ctype", str "body")` </a> 
 
-## xhttp_pi ##
-#### KSR.xhttp_pi.dispatch() ####
+## xhttp_pi
+
+#### KSR.xhttp_pi.dispatch()
+
 <a target='_blank' href='/docs/modules/devel/modules/xhttp_pi.html#xhttp_pi.f.dispatch'> `int dispatch()` </a> 
 
-## xhttp_rpc ##
-#### KSR.xhttp_rpc.dispatch() ####
+## xhttp_rpc
+
+#### KSR.xhttp_rpc.dispatch()
+
 <a target='_blank' href='/docs/modules/devel/modules/xhttp_rpc.html#xhttp_rpc.f.dispatch'> `int dispatch()` </a> 
 
-## xlog ##
-#### KSR.xlog.xalert() ####
+## xlog
+
+#### KSR.xlog.xalert()
+
 <a target='_blank' href='/docs/modules/devel/modules/xlog.html#xlog.f.xalert'> `int xalert(str "lmsg")` </a> 
 
-#### KSR.xlog.xcrit() ####
+#### KSR.xlog.xcrit()
+
 <a target='_blank' href='/docs/modules/devel/modules/xlog.html#xlog.f.xcrit'> `int xcrit(str "lmsg")` </a> 
 
-#### KSR.xlog.xdbg() ####
+#### KSR.xlog.xdbg()
+
 <a target='_blank' href='/docs/modules/devel/modules/xlog.html#xlog.f.xdbg'> `int xdbg(str "lmsg")` </a> 
 
-#### KSR.xlog.xerr() ####
+#### KSR.xlog.xerr()
+
 <a target='_blank' href='/docs/modules/devel/modules/xlog.html#xlog.f.xerr'> `int xerr(str "lmsg")` </a> 
 
-#### KSR.xlog.xinfo() ####
+#### KSR.xlog.xinfo()
+
 <a target='_blank' href='/docs/modules/devel/modules/xlog.html#xlog.f.xinfo'> `int xinfo(str "lmsg")` </a> 
 
-#### KSR.xlog.xlog() ####
+#### KSR.xlog.xlog()
+
 <a target='_blank' href='/docs/modules/devel/modules/xlog.html#xlog.f.xlog'> `int xlog(str "slevel", str "lmsg")` </a> 
 
-#### KSR.xlog.xnotice() ####
+#### KSR.xlog.xnotice()
+
 <a target='_blank' href='/docs/modules/devel/modules/xlog.html#xlog.f.xnotice'> `int xnotice(str "lmsg")` </a> 
 
-#### KSR.xlog.xwarn() ####
+#### KSR.xlog.xwarn()
+
 <a target='_blank' href='/docs/modules/devel/modules/xlog.html#xlog.f.xwarn'> `int xwarn(str "lmsg")` </a> 
 
-## xmlrpc ##
-#### KSR.xmlrpc.dispatch_rpc() ####
+## xmlrpc
+
+#### KSR.xmlrpc.dispatch_rpc()
+
 <a target='_blank' href='/docs/modules/devel/modules/xmlrpc.html#xmlrpc.f.dispatch_rpc'> `int dispatch_rpc()` </a> 
 
-#### KSR.xmlrpc.xmlrpc_reply() ####
+#### KSR.xmlrpc.xmlrpc_reply()
+
 <a target='_blank' href='/docs/modules/devel/modules/xmlrpc.html#xmlrpc.f.xmlrpc_reply'> `int xmlrpc_reply(int rcode, str "reason")` </a> 
 

--- a/kamailio-kemi-framework/docs/modules/header.md
+++ b/kamailio-kemi-framework/docs/modules/header.md
@@ -1,0 +1,3 @@
+<!-- This file is auto-generated. Any manual modifications will be deleted -->
+# KEMI Module Functions #
+The following sections lists all exported KEMI functions. More information regarding the function can be found by clicking the KEMI declaration which will take you the original modules documentation.

--- a/kamailio-kemi-framework/docs/modules/rtpengine.header.md
+++ b/kamailio-kemi-framework/docs/modules/rtpengine.header.md
@@ -1,0 +1,1 @@
+This module enables media streams to be proxied via an RTPproxy.

--- a/kamailio-kemi-framework/docs/modules/rtpengine.set_rtpengine_set2.md
+++ b/kamailio-kemi-framework/docs/modules/rtpengine.set_rtpengine_set2.md
@@ -1,0 +1,11 @@
+This function is the sibling function to [set_rtpengine_set()](#ksrrtpengineset_rtpengine_set). The original module function is declared as
+`set_rtpengine_set(setid[, setid])`.
+
+In KEMI set_rtpengine_set() takes only the first parameter and set_rtpengine_set2() allows for the second optional parameter to be passed.
+
+```
+KSR.rtpengine.set_rtpengine_set(2, 1);
+KSR.rtpengine.rtpengine_offer();
+```
+
+Please review the documentation for [set_rtpengine_set()](#ksrrtpengineset_rtpengine_set) for more information.

--- a/kamailio-kemi-framework/mkdocs.yml
+++ b/kamailio-kemi-framework/mkdocs.yml
@@ -9,3 +9,6 @@ pages:
     - 'Module Functions': 'modules.md'
     - 'Support': 'support.md'
     - 'Contributions': 'contributions.md'
+markdown_extensions:
+    - toc:
+        permalink: Link

--- a/kamailio-kemi-framework/mkdocs.yml
+++ b/kamailio-kemi-framework/mkdocs.yml
@@ -6,6 +6,6 @@ pages:
     - 'KEMI Interpreters': 'kemi.md'
     - 'Core Functions': 'core.md'
     - 'PV And Special Functions': 'kemimods.md'
-    - 'Acc Module Functions': 'acc.md'
+    - 'Module Functions': 'modules.md'
     - 'Support': 'support.md'
     - 'Contributions': 'contributions.md'

--- a/kamailio-kemi-framework/tools/generate_function_list.py
+++ b/kamailio-kemi-framework/tools/generate_function_list.py
@@ -1,0 +1,194 @@
+# This file generates the modules.md content
+# This file should be run in an environment where there is one, and only one, Kamailio install built from source
+import os, json, sys
+
+
+class ModuleDocGenerator(object):
+    PATH_GENERATED_JSON = "./generated_functions.json"
+    PATH_GENERATED_MARKDOWN = "../docs/modules.md"
+    # A source file in the tm module
+    SEARCH_DOCS_TM_FILE = "tm_load.c"
+
+    # Contains the output until it should be written to disk
+    markdown_string = ""
+    path_docs = ""
+
+    def execute(self):
+        path_kamctl = self.find("kamctl", "/")
+
+        # Obtain the KEMI function list through KAMCTL RPC
+        failed = os.system(path_kamctl + " rpc app_python.api_list > " + self.PATH_GENERATED_JSON)
+
+        if failed != 0:
+            print "ERR: Failed to execute KAMCTL"
+            exit()
+
+        functions_raw = json.load(open(self.PATH_GENERATED_JSON))
+
+        # Validate that we got some methods back. 155 is an arbitrary large number.
+        if functions_raw["result"]["msize"] < 155:
+            print "ERR: Invalid JSON RPC response"
+            exit()
+
+        functions_parsed = self.parse_function_list(functions_raw["result"]["methods"])
+        self.output_markdown(functions_parsed)
+
+        print "Markdown doc created successfully at " + self.PATH_GENERATED_MARKDOWN
+
+    def find(self, name, path):
+        for root, dirs, files in os.walk(path):
+            if name in files:
+                return os.path.join(root, name)
+
+    def parse_function_list(self, functions):
+        data = {}
+
+        for elem in functions:
+            props = elem["func"]
+            module = props["module"]
+
+            # The core and hdr submodule are documented in a different section
+            # TODO: What about the pvx module?
+            if module == "" or module == "hdr":
+                continue
+
+            if module not in data:
+                data[module] = []
+
+            data[module].append({"name": props["name"], "return": props["ret"], "params": props["params"]})
+
+        return data
+
+    def output_markdown(self, data):
+        self.markdown_header()
+
+        for key in sorted(data):
+            methods = data[key]
+            methods = sorted(methods, key = lambda k: k['name'])
+
+            self.markdown_section_heading(key)
+            self.markdown_section_content(key, methods)
+            self.markdown_write()
+
+        return True
+
+    def markdown_header(self):
+        self.markdown_string += "<!-- This file is auto-generated. Any manual modifications will be deleted -->\n"'' \
+        # TODO: Move the below markdown to a file in ../docs/modules/something.md
+        self.markdown_string += "# KEMI Module Functions #\n"
+        self.markdown_string += "The following sections lists all exported KEMI functions. More information regarding the function can be found by clicking the KEMI declaration which will take you the original modules documentation. \n"
+        return True
+
+    def markdown_section_heading(self, heading):
+        self.markdown_string += "## " + heading + " ##\n"
+        # TODO: Lookup if a file such as ../docs/modules/module.header.md exists and if so inject the markdown here
+        return True
+
+    def markdown_section_content(self, module, methods):
+        module_prefix = module + "."
+
+        for value in methods:
+            self.markdown_string += "#### KSR." + module_prefix + value["name"] + "() ####\n"
+
+            # Sanitize the return values
+            if value["return"] == "none":
+                return_value = "void"
+            else:
+                return_value = value["return"]
+
+            # Sanitize the parameter values
+            if value["params"] == "none":
+                params_value = ""
+            else:
+                params_value = value["params"]
+
+            docs_params = self.generate_param_definitions(params_value, module, value["name"])
+
+            # Generate the output string for the markdown page
+            self.markdown_string += "KEMI declaration: " "<a target='_blank' href='/docs/modules/devel/modules/" + module + ".html#" \
+                                    + module + ".f." + value["name"] + "'> `" + return_value + " " + value["name"] \
+                                    + "(" + params_value + ")` </a> \n\n"
+
+            # If we found a definition in the Docs let's present it as well
+            if params_value != docs_params:
+                self.markdown_string += "Docs declaration: `" + return_value + " " + value[
+                    "name"] + "(" + docs_params + ")`\n"
+
+            # TODO: Lookup if a file such as ../docs/modules/module.function.md exists and if so inject the markdown here
+        return True
+
+    def markdown_write(self):
+        f = open(self.PATH_GENERATED_MARKDOWN, "w")
+        f.write(self.markdown_string)
+        f.close()
+        return True
+
+    def generate_param_definitions(self, params_kemi, module, function):
+        if params_kemi == "":
+            return ""
+
+        # print params_kemi, module, function
+        params_original = self.find_function_parameters(module, function)
+
+        if params_original is None:
+            return params_kemi
+
+        # Remove redundant information
+        if params_original == "str" or params_original == "str" or params_original == "int" or params_original == "integer" or params_original == "param":
+            return ""
+
+        return params_original
+
+    def find_function_parameters(self, module, function):
+        path_modules = self.locate_docs_path()
+        path_readme = path_modules + module + "/README"
+
+        if not os.path.isfile(path_readme):
+            print "ERR: Could not find README for module: " + module
+            return None
+
+        with open(path_readme) as f:
+            content = f.readlines()
+
+        match = False
+
+        for line in content:
+            if line.find(function + "(") >= 0:
+                match = True
+                break
+            elif line.find(function + " (") >= 0:
+                match = True
+                break
+
+        if not match:
+            print "ERR: Could not find definition for function: " + module + "." + function
+            return None
+
+        # Get all content between parenthesises
+        params = line[line.find("(") + 1:line.find(")")]
+        if params == "":
+            return None
+
+        return params
+
+    def locate_docs_path(self):
+        if self.path_docs == "":
+            # We look for a file in the Kamailio source and work our way backwards from there
+            path = self.find(self.SEARCH_DOCS_TM_FILE, "/")
+            if path:
+                strip_path = "tm/" + self.SEARCH_DOCS_TM_FILE
+                path = path[:-len(strip_path)]
+                self.path_docs = path
+                return path
+            else:
+                print "ERR: Could not find the path to the Kamailio source"
+                exit()
+        else:
+            return self.path_docs
+
+
+if __name__ == "__main__":
+    reload(sys)
+    sys.setdefaultencoding('utf8')
+    fgen = ModuleDocGenerator()
+    fgen.execute()


### PR DESCRIPTION
Documentation for exported KEMI functions was added for all modules except the Core/HDR submodules as they are already added. 

If this is a route we want to go I will add additional functionality so we can customize the documentation for each function in the modules list as well. I have a few ideas on how to improve it further and make it more usable but this PR proposes the basic structure.

I am yet to commit the updated version of the python script, need to clean it up a little bit but wanted to present the documentation at least.

I'd like to receive comments on the structure of the documentation (markdown) itself, if the format is good or if it should be changed?