### PR TITLE
Clarify return values of `pv.get`

### DIFF
--- a/kamailio-kemi-framework/docs/core.md
+++ b/kamailio-kemi-framework/docs/core.md
@@ -644,7 +644,7 @@ Note: functions exported by Kamailio's `pv` module are in `KSR.pvx` package.
 
 `xval KSR.pv.get(str "pvname")`
 
-Return the value of pseudo-variable `pvname`. The returned value can be string or integer.
+Return the value of pseudo-variable `pvname`. The returned value can be string, integer or null (if pseudo-variable isn't set or `$null`).
 
 Example:
 


### PR DESCRIPTION
`pv.get(...)` returns `$null` if requested pseudo-variable isn't set. To prevent this one could use `pv.gete(...)`, which is available since kamailio 5.2.x.