### PR TITLE
kemi: update supported Lua versions

### DIFF
--- a/kamailio-kemi-framework/docs/kemi.md
+++ b/kamailio-kemi-framework/docs/kemi.md
@@ -76,7 +76,7 @@ The documentation for `app_jsdk` is available at:
 ### Lua KEMI Interpreter ###
 
 It is implemented by `app_lua` module. The Lua interpreter is linked from `liblua` library, supported Lua versions: 
-5.1 and 5.2.
+5.1, 5.2, 5.3, and 5.4.
 
 ```
 loadmodule "app_lua.so"


### PR DESCRIPTION
Since https://github.com/kamailio/kamailio/commit/2e85bb541ff19e4b007 and https://github.com/kamailio/kamailio/commit/673dab16593d9a70b Lua 5.3 and 5.4 can be used in KEMI.